### PR TITLE
UserState가 created일때만 로그인되게 수정

### DIFF
--- a/src/main/kotlin/com/msg/gauth/domain/auth/exception/UserIsPendingException.kt
+++ b/src/main/kotlin/com/msg/gauth/domain/auth/exception/UserIsPendingException.kt
@@ -1,0 +1,8 @@
+package com.msg.gauth.domain.auth.exception
+
+import com.msg.gauth.global.exception.ErrorCode
+import com.msg.gauth.global.exception.exceptions.BasicException
+
+class UserIsPendingException: BasicException(
+    ErrorCode.USER_STATE_PENDING
+)

--- a/src/main/kotlin/com/msg/gauth/domain/auth/services/SignInService.kt
+++ b/src/main/kotlin/com/msg/gauth/domain/auth/services/SignInService.kt
@@ -2,10 +2,12 @@ package com.msg.gauth.domain.auth.services
 
 import com.msg.gauth.domain.auth.RefreshToken
 import com.msg.gauth.domain.auth.exception.PasswordMismatchException
+import com.msg.gauth.domain.auth.exception.UserIsPendingException
 import com.msg.gauth.domain.auth.presentation.dto.request.SigninRequestDto
 import com.msg.gauth.domain.auth.presentation.dto.response.SigninResponseDto
 import com.msg.gauth.domain.auth.repository.RefreshTokenRepository
 import com.msg.gauth.domain.user.User
+import com.msg.gauth.domain.user.enums.UserState
 import com.msg.gauth.domain.user.exception.UserNotFoundException
 import com.msg.gauth.domain.user.repository.UserRepository
 import com.msg.gauth.global.security.jwt.JwtTokenProvider
@@ -26,7 +28,8 @@ class SignInService(
         val user: User = userRepository.findByEmail(dto.email) ?: throw UserNotFoundException()
         if (!passwordEncoder.matches(dto.password, user.password))
             throw PasswordMismatchException()
-
+        if(user.state != UserState.CREATED)
+            throw UserIsPendingException()
         val access = jwtTokenProvider.generateAccessToken(dto.email)
         val refresh = jwtTokenProvider.generateRefreshToken(dto.email)
         val expiresAt = jwtTokenProvider.accessExpiredTime

--- a/src/main/kotlin/com/msg/gauth/domain/oauth/services/OauthCodeService.kt
+++ b/src/main/kotlin/com/msg/gauth/domain/oauth/services/OauthCodeService.kt
@@ -2,9 +2,11 @@ package com.msg.gauth.domain.oauth.services
 
 import com.msg.gauth.domain.auth.exception.PasswordMismatchException
 import com.msg.gauth.domain.oauth.OauthCode
+import com.msg.gauth.domain.oauth.exception.UserStatePendingException
 import com.msg.gauth.domain.oauth.presentation.dto.request.OauthCodeRequestDto
 import com.msg.gauth.domain.oauth.presentation.dto.response.OauthCodeResponseDto
 import com.msg.gauth.domain.oauth.repository.OauthCodeRepository
+import com.msg.gauth.domain.user.enums.UserState
 import com.msg.gauth.domain.user.exception.UserNotFoundException
 import com.msg.gauth.domain.user.repository.UserRepository
 import org.springframework.data.redis.core.RedisTemplate
@@ -22,9 +24,10 @@ class OauthCodeService(
     @Transactional(readOnly = true, rollbackFor = [Exception::class])
     fun execute(oauthLoginRequestDto: OauthCodeRequestDto): OauthCodeResponseDto {
         val user = userRepository.findByEmail(oauthLoginRequestDto.email) ?: throw UserNotFoundException()
-        if (!passwordEncoder.matches(oauthLoginRequestDto.password, user.password)) {
+        if (!passwordEncoder.matches(oauthLoginRequestDto.password, user.password))
             throw PasswordMismatchException()
-        }
+        if(user.state != UserState.CREATED)
+            throw UserStatePendingException()
         val code = UUID.randomUUID().toString().split(".")[0]
         oauthCodeRepository.save(OauthCode(code, user.email))
         return OauthCodeResponseDto(


### PR DESCRIPTION
## 💡 개요
- gauth로그인과 oauth로그인할때 유저 상태가 created일때만 되게끔 수정했습니다.

## 📃 작업내용
- UserIsPendingException추가
- 자채 로그인에서 state검사 로직 추가
- oauth로직에서도 state검사 로직 추가

## 🔀 변경사항
```kt
if(user.state != UserState.CREATED)
    throw UserStatePendingException()
```
모든 로그인 로직에 요거 추가
