### PR TITLE
Oauth용 토큰

### DIFF
--- a/src/main/kotlin/com/msg/gauth/domain/oauth/services/OauthRefreshService.kt
+++ b/src/main/kotlin/com/msg/gauth/domain/oauth/services/OauthRefreshService.kt
@@ -18,12 +18,13 @@ class OauthRefreshService(
 ){
     fun execute(refreshToken: String): UserTokenResponseDto{
         val refreshToken = tokenProvider.parseToken(refreshToken) ?: throw InvalidRefreshTokenException()
-        val email = tokenProvider.exactEmailFromRefreshToken(refreshToken)
+        val email = tokenProvider.exactEmailFromOauthRefreshToken(refreshToken)
         val user = userRepository.findByEmail(email) ?: throw UserNotFoundException()
         if(!tokenRepository.existsById(user.id))
             throw ExpiredRefreshTokenException()
-        val access = tokenProvider.generateAccessToken(email)
-        val refresh = tokenProvider.generateRefreshToken(email)
+        val clientId = tokenProvider.exactClientIdFromOauthRefreshToken(refreshToken)
+        val access = tokenProvider.generateOauthAccessToken(email, clientId)
+        val refresh = tokenProvider.generateOauthRefreshToken(email, clientId)
         val expiresAt = tokenProvider.accessExpiredTime
         val newRefreshToken = OauthRefreshToken(
             userId = user.id,

--- a/src/main/kotlin/com/msg/gauth/global/security/jwt/JwtProperties.kt
+++ b/src/main/kotlin/com/msg/gauth/global/security/jwt/JwtProperties.kt
@@ -10,13 +10,16 @@ import java.security.Key
 @ConfigurationProperties(prefix = "jwt")
 class JwtProperties(
     accessSecret: String,
-    refreshSecret: String
+    refreshSecret: String,
+    oauthSecret: String,
 ) {
     val accessSecret: Key
     val refreshSecret: Key
+    val oauthSecret: Key
 
     init {
         this.accessSecret = Keys.hmacShaKeyFor(accessSecret.toByteArray(StandardCharsets.UTF_8))
         this.refreshSecret = Keys.hmacShaKeyFor(refreshSecret.toByteArray(StandardCharsets.UTF_8))
+        this.oauthSecret = Keys.hmacShaKeyFor(oauthSecret.toByteArray(StandardCharsets.UTF_8))
     }
 }


### PR DESCRIPTION
## 💡 개요
* 리소스 서버에서 클라이언트를 구분하기 위해서 Oauth전용 토큰을 만들어야됨

## 📃 작업내용
* OauthSecret추가
* Oauth토큰에서 클라이언트 아이디 가져오는 메서드 추가
* Oauth리프레시 토큰에서 이메일 가져오는 메서드 추가

## 🔀 변경사항
* Oauth 리프레시 로직과 토큰발급 로직 변경

## 🎸 기타
#52 
