### PR TITLE
이메일이 인증되었을때 인증코드 발송X

### DIFF
--- a/src/main/kotlin/com/msg/gauth/domain/email/exception/AlreadyAuthenticatedEmailException.kt
+++ b/src/main/kotlin/com/msg/gauth/domain/email/exception/AlreadyAuthenticatedEmailException.kt
@@ -1,0 +1,6 @@
+package com.msg.gauth.domain.email.exception
+
+import com.msg.gauth.global.exception.ErrorCode
+import com.msg.gauth.global.exception.exceptions.BasicException
+
+class AlreadyAuthenticatedEmailException: BasicException(ErrorCode.ALREADY_AUTHENTICATED_MAIL)

--- a/src/main/kotlin/com/msg/gauth/domain/email/services/MailSendService.kt
+++ b/src/main/kotlin/com/msg/gauth/domain/email/services/MailSendService.kt
@@ -1,9 +1,11 @@
 package com.msg.gauth.domain.email.services
 
 import com.msg.gauth.domain.email.EmailAuthEntity
+import com.msg.gauth.domain.email.exception.AlreadyAuthenticatedEmailException
 import com.msg.gauth.domain.email.exception.ManyRequestEmailAuthException
 import com.msg.gauth.domain.email.presentation.dto.EmailSendDto
 import com.msg.gauth.domain.email.repository.EmailAuthRepository
+import com.msg.gauth.domain.user.repository.UserRepository
 import com.msg.gauth.global.exception.exceptions.MessageSendFailException
 import org.springframework.mail.javamail.JavaMailSender
 import org.springframework.scheduling.annotation.Async
@@ -34,6 +36,8 @@ class MailSendService(
                     attemptCount = 0
                 )
             )
+        if(authEntity.authentication)
+            throw AlreadyAuthenticatedEmailException()
         if (authEntity.attemptCount >= 3) throw ManyRequestEmailAuthException()
         val updateEmailAuth = authEntity.resendEmailAuth(value)
         emailAuthRepository.save(updateEmailAuth)

--- a/src/main/kotlin/com/msg/gauth/global/exception/ErrorCode.kt
+++ b/src/main/kotlin/com/msg/gauth/global/exception/ErrorCode.kt
@@ -8,6 +8,7 @@ enum class ErrorCode(
     PASSWORD_MISMATCH("비밀번호가 일치하지 않습니다.", 400),
     CLIENT_SECRET_MISMATCH("클라이언트 시크릿이 일치하지 않습니다.", 400),
     FILE_EXTENSION_INVALID("파일 확장자가 유효하지 않습니다.", 400),
+    ALREADY_AUTHENTICATED_MAIL("이미 인증된 메일 입니다.", 400),
 
     AUTH_CODE_EXPIRED("메일 인증이 만료되었습니다.", 401),
     UNAUTHORIZED("권한 없음", 401),


### PR DESCRIPTION
## 💡 개요
* 이미 인증한 메일은 인증코드 보낼수 없도록 변경

## 🎸 기타
#58
* 회원가입한 메일도 못보내게 하면 패스워드 변경할때 못보내서 이미 인증되었을때만 되게끔 변경했습니다
