### PR TITLE
🔀 :: oauth 토큰 response에 expiresAt 제거

### DIFF
--- a/src/main/kotlin/com/msg/gauth/domain/oauth/presentation/OauthController.kt
+++ b/src/main/kotlin/com/msg/gauth/domain/oauth/presentation/OauthController.kt
@@ -37,8 +37,4 @@ class OauthController(
     @GetMapping("/{clientId}")
     fun getServiceName(@PathVariable clientId: String): ResponseEntity<ServiceNameResponseDto> =
         ResponseEntity.ok(getServiceNameService.execute(clientId))
-
-    @PostMapping("/signin")
-    fun oauthSignin(@RequestBody oauthLoginReqDto: OauthLoginReqDto): ResponseEntity<UserTokenResponseDto> =
-        ResponseEntity.ok(oauthTokenService.execute(oauthLoginReqDto))
 }

--- a/src/main/kotlin/com/msg/gauth/domain/oauth/presentation/dto/response/UserTokenResponseDto.kt
+++ b/src/main/kotlin/com/msg/gauth/domain/oauth/presentation/dto/response/UserTokenResponseDto.kt
@@ -5,7 +5,5 @@ import java.time.ZonedDateTime
 
 data class UserTokenResponseDto(
     val accessToken: String,
-    val refreshToken: String,
-    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ss")
-    val expiresAt: ZonedDateTime,
+    val refreshToken: String
 )

--- a/src/main/kotlin/com/msg/gauth/domain/oauth/services/OauthRefreshService.kt
+++ b/src/main/kotlin/com/msg/gauth/domain/oauth/services/OauthRefreshService.kt
@@ -25,12 +25,11 @@ class OauthRefreshService(
         val clientId = tokenProvider.exactClientIdFromOauthRefreshToken(refreshToken)
         val access = tokenProvider.generateOauthAccessToken(email, clientId)
         val refresh = tokenProvider.generateOauthRefreshToken(email, clientId)
-        val expiresAt = tokenProvider.accessExpiredTime
         val newRefreshToken = OauthRefreshToken(
             userId = user.id,
             token = refresh,
         )
         tokenRepository.save(newRefreshToken)
-        return UserTokenResponseDto(access, refresh, expiresAt)
+        return UserTokenResponseDto(access, refresh)
     }
 }


### PR DESCRIPTION
## 💡 개요
oauth 토큰 response에 expiresAt 제거

## 📃 작업내용
- oauth 토큰 response에 expiresAt 제거
- 이메일, clientID 기반 OAuth 로그인 API 제거
