### PR TITLE
🔀  :: 180 - 로그인 성공시 틀린 횟수 초기화

### DIFF
--- a/src/main/kotlin/com/msg/gauth/domain/auth/service/SignInService.kt
+++ b/src/main/kotlin/com/msg/gauth/domain/auth/service/SignInService.kt
@@ -40,6 +40,8 @@ class SignInService(
         if(user.state != UserState.CREATED)
             throw UserIsPendingException()
 
+        tempUserUtil.resetWrongPasswordCount(user)
+
         val (access, refresh) = jwtTokenProvider.run {
             generateAccessToken(dto.email) to generateRefreshToken(dto.email)}
 

--- a/src/main/kotlin/com/msg/gauth/domain/auth/service/SignInService.kt
+++ b/src/main/kotlin/com/msg/gauth/domain/auth/service/SignInService.kt
@@ -37,7 +37,7 @@ class SignInService(
             throw PasswordMismatchException()
         }
 
-        if(user.state != UserState.CREATED)
+        if(user.state == UserState.PENDING)
             throw UserIsPendingException()
 
         tempUserUtil.resetWrongPasswordCount(user)

--- a/src/main/kotlin/com/msg/gauth/domain/oauth/service/GenerateOauthCodeService.kt
+++ b/src/main/kotlin/com/msg/gauth/domain/oauth/service/GenerateOauthCodeService.kt
@@ -48,6 +48,7 @@ class   GenerateOauthCodeService(
 
         val code = UUID.randomUUID().toString().split(".")[0]
 
+        tempUserUtil.resetOAuthWrongPasswordCount(user)
         oauthCodeRepository.save(OauthCode(code, user.email))
         return OauthCodeResponseDto(
             code = code,

--- a/src/main/kotlin/com/msg/gauth/domain/oauth/service/GenerateOauthCodeService.kt
+++ b/src/main/kotlin/com/msg/gauth/domain/oauth/service/GenerateOauthCodeService.kt
@@ -46,9 +46,10 @@ class   GenerateOauthCodeService(
         if(user.state == UserState.PENDING)
             throw UserStatePendingException()
 
+        tempUserUtil.resetOAuthWrongPasswordCount(user)
+
         val code = UUID.randomUUID().toString().split(".")[0]
 
-        tempUserUtil.resetOAuthWrongPasswordCount(user)
         oauthCodeRepository.save(OauthCode(code, user.email))
         return OauthCodeResponseDto(
             code = code,

--- a/src/main/kotlin/com/msg/gauth/domain/user/util/TempUserUtil.kt
+++ b/src/main/kotlin/com/msg/gauth/domain/user/util/TempUserUtil.kt
@@ -132,4 +132,24 @@ class TempUserUtil(
             )
         )
     }
+
+    fun resetWrongPasswordCount(user: User) {
+        userRepository.save(
+            User(
+                id = user.id,
+                email = user.email,
+                password = user.password,
+                gender = user.gender,
+                name = user.name,
+                grade = user.grade,
+                classNum = user.classNum,
+                num = user.num,
+                roles = user.roles,
+                state = user.state,
+                profileUrl = user.profileUrl,
+                wrongPasswordCount = 0,
+                oauthWrongPasswordCount = user.oauthWrongPasswordCount
+            )
+        )
+    }
 }

--- a/src/main/kotlin/com/msg/gauth/domain/user/util/TempUserUtil.kt
+++ b/src/main/kotlin/com/msg/gauth/domain/user/util/TempUserUtil.kt
@@ -112,4 +112,24 @@ class TempUserUtil(
             tempOAuthSignInBanRepository.existsById(user.email) -> throw TempSignInBanException()
         }
     }
+
+    fun resetOAuthWrongPasswordCount(user: User) {
+        userRepository.save(
+            User(
+                id = user.id,
+                email = user.email,
+                password = user.password,
+                gender = user.gender,
+                name = user.name,
+                grade = user.grade,
+                classNum = user.classNum,
+                num = user.num,
+                roles = user.roles,
+                state = user.state,
+                profileUrl = user.profileUrl,
+                wrongPasswordCount = user.wrongPasswordCount,
+                oauthWrongPasswordCount = 0
+            )
+        )
+    }
 }


### PR DESCRIPTION
## 💡 개요
* 계속 누적하니까 뜬금없이 로그인 정지 당하는 경우가 많음

## 📃 작업내용
* 로그인 성공시 틀린 횟수 초기화
* OAuth 로그인 성공시 틀린 횟수 초기화 

## 🔀 변경사항
* 로그인 로직에서 pending상태를 검증하게 수정

## 🙋‍♂️ 질문사항

## ⚗️ 사용법

## 🎸 기타
