### PR TITLE
:art: :: requestParam null 허용

### DIFF
--- a/src/main/kotlin/com/msg/gauth/domain/user/presentation/dto/request/AcceptedUserRequest.kt
+++ b/src/main/kotlin/com/msg/gauth/domain/user/presentation/dto/request/AcceptedUserRequest.kt
@@ -4,8 +4,8 @@ import com.msg.gauth.domain.user.enums.UserRole
 import org.springframework.web.bind.annotation.RequestParam
 
 data class AcceptedUserRequest(
-    @RequestParam val grade: Int = 0,
-    @RequestParam val classNum: Int = 0,
-    @RequestParam val keyword: String = "",
-    @RequestParam val role: UserRole = UserRole.ROLE_STUDENT
+    @RequestParam(required = false) val grade: Int = 0,
+    @RequestParam(required = false) val classNum: Int = 0,
+    @RequestParam(required = false) val keyword: String = "",
+    @RequestParam(required = false) val role: UserRole = UserRole.ROLE_STUDENT
 )


### PR DESCRIPTION
## 💡 개요
유저 리스트를 전체 조회할 때 원래 정해진 값을 파라미터에 넣어 보내야 전체 검색이 되었는데 파라미터를 보내지 않으면 전체 조회가 되도록 RequestParam의 required 속성을 false로 바꾸어주었습니다
## 📃 작업내용

## 🔀 변경사항

## 🙋‍♂️ 질문사항

## ⚗️ 사용법

## 🎸 기타
