### PR TITLE
refactor :: OAuthTokenProvider, JwtTokenProvider 공통 parseToken 로직 분리

### DIFF
--- a/src/main/kotlin/com/msg/gauth/domain/auth/service/RefreshService.kt
+++ b/src/main/kotlin/com/msg/gauth/domain/auth/service/RefreshService.kt
@@ -7,15 +7,17 @@ import com.msg.gauth.domain.auth.presentation.dto.response.RefreshResponseDto
 import com.msg.gauth.domain.auth.repository.RefreshTokenRepository
 import com.msg.gauth.global.annotation.service.TransactionalService
 import com.msg.gauth.global.security.jwt.JwtTokenProvider
+import com.msg.gauth.global.security.jwt.TokenParser
 
 @TransactionalService
 class RefreshService(
     private val jwtTokenProvider: JwtTokenProvider,
-    private val refreshTokenRepository: RefreshTokenRepository
+    private val refreshTokenRepository: RefreshTokenRepository,
+    private val tokenParser: TokenParser
 ) {
     fun execute(requestToken: String): RefreshResponseDto {
-        val refreshToken = jwtTokenProvider.parseToken(requestToken) ?: throw InvalidRefreshTokenException()
-        val email = jwtTokenProvider.exactEmailFromRefreshToken(refreshToken)
+        val refreshToken = tokenParser.parseToken(requestToken) ?: throw InvalidRefreshTokenException()
+        val email = tokenParser.exactEmailFromRefreshToken(refreshToken)
 
         val existingRefreshToken = refreshTokenRepository.findByToken(refreshToken)
             ?: throw ExpiredRefreshTokenException()

--- a/src/main/kotlin/com/msg/gauth/domain/oauth/OauthCode.kt
+++ b/src/main/kotlin/com/msg/gauth/domain/oauth/OauthCode.kt
@@ -1,4 +1,4 @@
-package com.msg.gauth.global.util.count.oauth
+package com.msg.gauth.domain.oauth
 
 import org.springframework.data.annotation.Id
 import org.springframework.data.redis.core.RedisHash

--- a/src/main/kotlin/com/msg/gauth/domain/oauth/repository/OauthCodeRepository.kt
+++ b/src/main/kotlin/com/msg/gauth/domain/oauth/repository/OauthCodeRepository.kt
@@ -1,6 +1,6 @@
 package com.msg.gauth.domain.oauth.repository
 
-import com.msg.gauth.global.util.count.oauth.OauthCode
+import com.msg.gauth.domain.oauth.OauthCode
 import org.springframework.data.repository.CrudRepository
 
 interface OauthCodeRepository: CrudRepository<OauthCode, String> {

--- a/src/main/kotlin/com/msg/gauth/domain/oauth/service/GenerateOauthCodeService.kt
+++ b/src/main/kotlin/com/msg/gauth/domain/oauth/service/GenerateOauthCodeService.kt
@@ -1,7 +1,7 @@
 package com.msg.gauth.domain.oauth.service
 
 import com.msg.gauth.domain.auth.exception.PasswordMismatchException
-import com.msg.gauth.global.util.count.oauth.OauthCode
+import com.msg.gauth.domain.oauth.OauthCode
 import com.msg.gauth.domain.oauth.exception.UserStatePendingException
 import com.msg.gauth.domain.oauth.presentation.dto.request.OauthCodeRequestDto
 import com.msg.gauth.domain.oauth.presentation.dto.response.OauthCodeResponseDto

--- a/src/main/kotlin/com/msg/gauth/domain/oauth/service/RefreshOauthTokenService.kt
+++ b/src/main/kotlin/com/msg/gauth/domain/oauth/service/RefreshOauthTokenService.kt
@@ -9,18 +9,20 @@ import com.msg.gauth.domain.user.exception.UserNotFoundException
 import com.msg.gauth.domain.user.repository.UserRepository
 import com.msg.gauth.global.annotation.service.TransactionalService
 import com.msg.gauth.global.security.jwt.OauthTokenProvider
+import com.msg.gauth.global.security.jwt.TokenParser
 
 @TransactionalService
 class RefreshOauthTokenService(
     private val tokenRepository: OauthRefreshTokenRepository,
     private val oauthTokenProvider: OauthTokenProvider,
     private val userRepository: UserRepository,
+    private val tokenParser: TokenParser
 ){
     fun execute(requestToken: String): OauthTokenResponseDto{
-        val refreshToken = oauthTokenProvider.parseToken(requestToken)
+        val refreshToken = tokenParser.parseToken(requestToken)
             ?: throw InvalidRefreshTokenException()
 
-        val (email, clientId) = oauthTokenProvider.run {
+        val (email, clientId) = tokenParser.run {
             exactEmailFromOauthRefreshToken(refreshToken) to exactClientIdFromOauthRefreshToken(refreshToken)
         }
         val user = userRepository.findByEmail(email)

--- a/src/main/kotlin/com/msg/gauth/global/filter/JwtTokenFilter.kt
+++ b/src/main/kotlin/com/msg/gauth/global/filter/JwtTokenFilter.kt
@@ -1,6 +1,7 @@
 package com.msg.gauth.global.filter
 
 import com.msg.gauth.global.security.jwt.JwtTokenProvider
+import com.msg.gauth.global.security.jwt.TokenParser
 import org.springframework.security.core.context.SecurityContextHolder
 import org.springframework.web.filter.OncePerRequestFilter
 import javax.servlet.FilterChain
@@ -8,6 +9,7 @@ import javax.servlet.http.HttpServletRequest
 import javax.servlet.http.HttpServletResponse
 
 class JwtTokenFilter(
+    private val tokenParser: TokenParser,
     private val jwtTokenProvider: JwtTokenProvider
 ): OncePerRequestFilter() {
 
@@ -18,7 +20,7 @@ class JwtTokenFilter(
     ) {
         val token: String? = jwtTokenProvider.resolveToken(request)
         if (!token.isNullOrBlank()) {
-            val authentication = jwtTokenProvider.authentication(token)
+            val authentication = tokenParser.authentication(token)
             SecurityContextHolder.getContext().authentication = authentication
         }
         filterChain.doFilter(request, response)

--- a/src/main/kotlin/com/msg/gauth/global/security/SecurityConfig.kt
+++ b/src/main/kotlin/com/msg/gauth/global/security/SecurityConfig.kt
@@ -3,6 +3,7 @@ package com.msg.gauth.global.security
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.msg.gauth.global.security.config.FilterConfig
 import com.msg.gauth.global.security.jwt.JwtTokenProvider
+import com.msg.gauth.global.security.jwt.TokenParser
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 import org.springframework.http.HttpMethod
@@ -17,6 +18,7 @@ import org.springframework.web.cors.CorsUtils
 @Configuration
 class SecurityConfig(
     private val jwtTokenProvider: JwtTokenProvider,
+    private val tokenParser: TokenParser,
     private val objectMapper: ObjectMapper
 ) {
     @Bean
@@ -89,7 +91,7 @@ class SecurityConfig(
             .accessDeniedHandler(CustomAccessDeniedHandler(objectMapper))
 
             .and()
-            .apply(FilterConfig(jwtTokenProvider, objectMapper))
+            .apply(FilterConfig(tokenParser, jwtTokenProvider,  objectMapper))
 
             .and()
             .build()

--- a/src/main/kotlin/com/msg/gauth/global/security/config/FilterConfig.kt
+++ b/src/main/kotlin/com/msg/gauth/global/security/config/FilterConfig.kt
@@ -5,18 +5,20 @@ import com.msg.gauth.global.filter.ExceptionFilter
 import com.msg.gauth.global.filter.JwtTokenFilter
 import com.msg.gauth.global.filter.RequestLogFilter
 import com.msg.gauth.global.security.jwt.JwtTokenProvider
+import com.msg.gauth.global.security.jwt.TokenParser
 import org.springframework.security.config.annotation.SecurityConfigurerAdapter
 import org.springframework.security.config.annotation.web.builders.HttpSecurity
 import org.springframework.security.web.DefaultSecurityFilterChain
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter
 
 class FilterConfig(
+    private val tokenParser: TokenParser,
     private val jwtTokenProvider: JwtTokenProvider,
     private val objectMapper: ObjectMapper
 ): SecurityConfigurerAdapter<DefaultSecurityFilterChain?, HttpSecurity>() {
 
     override fun configure(builder: HttpSecurity) {
-        val jwtTokenFilter = JwtTokenFilter(jwtTokenProvider)
+        val jwtTokenFilter = JwtTokenFilter(tokenParser, jwtTokenProvider)
         val exceptionFilter = ExceptionFilter(objectMapper)
         val requestLogFilter = RequestLogFilter()
         builder.addFilterBefore(requestLogFilter, UsernamePasswordAuthenticationFilter::class.java)

--- a/src/main/kotlin/com/msg/gauth/global/security/jwt/OauthTokenProvider.kt
+++ b/src/main/kotlin/com/msg/gauth/global/security/jwt/OauthTokenProvider.kt
@@ -21,7 +21,6 @@ class OauthTokenProvider(
         const val OAUTH_REFRESH_TYPE = "refresh"
         const val OAUTH_ACCESS_EXP = 60L * 15 // 15 min
         const val OAUTH_REFRESH_EXP = 60L * 60 * 24 * 7 // 1 weeks
-        const val TOKEN_PREFIX = "Bearer "
     }
 
     fun generateOauthAccessToken(email: String, clientId: String): String =
@@ -45,32 +44,6 @@ class OauthTokenProvider(
             .setIssuedAt(Date())
             .setExpiration(Date(System.currentTimeMillis() + exp * 1000))
             .compact()
-
-    fun parseToken(token: String): String? =
-        if (token.startsWith(TOKEN_PREFIX)) token.replace(TOKEN_PREFIX, "") else null
-
-    fun exactEmailFromOauthRefreshToken(refresh: String): String =
-        getTokenSubject(refresh, jwtProperties.oauthSecret)
-
-    fun exactClientIdFromOauthRefreshToken(refresh: String): String =
-        getTokenBody(refresh, jwtProperties.oauthSecret)["clientId"].toString()
-
-    private fun getTokenBody(token: String, secret: Key): Claims {
-        return try {
-            Jwts.parserBuilder()
-                .setSigningKey(secret)
-                .build()
-                .parseClaimsJws(token)
-                .body
-        } catch (e: ExpiredJwtException) {
-            throw ExpiredTokenException()
-        } catch (e: Exception) {
-            throw InvalidTokenException()
-        }
-    }
-
-    private fun getTokenSubject(token: String, secret: Key): String =
-        getTokenBody(token, secret).subject
 
 }
 

--- a/src/main/kotlin/com/msg/gauth/global/security/jwt/TokenParser.kt
+++ b/src/main/kotlin/com/msg/gauth/global/security/jwt/TokenParser.kt
@@ -1,0 +1,57 @@
+package com.msg.gauth.global.security.jwt
+
+import com.msg.gauth.global.security.auth.AuthDetailsService
+import com.msg.gauth.global.security.exception.ExpiredTokenException
+import com.msg.gauth.global.security.exception.InvalidTokenException
+import io.jsonwebtoken.Claims
+import io.jsonwebtoken.ExpiredJwtException
+import io.jsonwebtoken.Jwts
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken
+import org.springframework.security.core.Authentication
+import org.springframework.stereotype.Component
+import java.security.Key
+
+@Component
+class TokenParser(
+    private val jwtProperties: JwtProperties,
+    private val authDetailsService: AuthDetailsService
+) {
+
+    fun exactEmailFromRefreshToken(refresh: String): String {
+        return getTokenSubject(refresh, jwtProperties.refreshSecret)
+    }
+
+    fun exactEmailFromOauthRefreshToken(refresh: String): String =
+        getTokenSubject(refresh, jwtProperties.oauthSecret)
+
+    fun exactClientIdFromOauthRefreshToken(refresh: String): String =
+        getTokenBody(refresh, jwtProperties.oauthSecret)["clientId"].toString()
+
+    fun authentication(token: String): Authentication {
+        val userDetails = authDetailsService.loadUserByUsername(getTokenSubject(token, jwtProperties.accessSecret))
+        return UsernamePasswordAuthenticationToken(userDetails, "", userDetails.authorities)
+    }
+
+    fun parseToken(token: String): String? =
+        if (token.startsWith(JwtTokenProvider.TOKEN_PREFIX)) token.replace(JwtTokenProvider.TOKEN_PREFIX, "") else null
+
+
+    private fun getTokenBody(token: String, secret: Key): Claims {
+        return try {
+            Jwts.parserBuilder()
+                .setSigningKey(secret)
+                .build()
+                .parseClaimsJws(token)
+                .body
+        } catch (e: ExpiredJwtException) {
+            throw ExpiredTokenException()
+        } catch (e: Exception) {
+            throw InvalidTokenException()
+        }
+    }
+
+    private fun getTokenSubject(token: String, secret: Key): String =
+        getTokenBody(token, secret).subject
+
+
+}

--- a/src/main/kotlin/com/msg/gauth/global/security/jwt/TokenParser.kt
+++ b/src/main/kotlin/com/msg/gauth/global/security/jwt/TokenParser.kt
@@ -17,6 +17,9 @@ class TokenParser(
     private val authDetailsService: AuthDetailsService
 ) {
 
+    fun parseToken(token: String): String? =
+        if (token.startsWith(JwtTokenProvider.TOKEN_PREFIX)) token.replace(JwtTokenProvider.TOKEN_PREFIX, "") else null
+
     fun exactEmailFromRefreshToken(refresh: String): String {
         return getTokenSubject(refresh, jwtProperties.refreshSecret)
     }
@@ -31,10 +34,6 @@ class TokenParser(
         val userDetails = authDetailsService.loadUserByUsername(getTokenSubject(token, jwtProperties.accessSecret))
         return UsernamePasswordAuthenticationToken(userDetails, "", userDetails.authorities)
     }
-
-    fun parseToken(token: String): String? =
-        if (token.startsWith(JwtTokenProvider.TOKEN_PREFIX)) token.replace(JwtTokenProvider.TOKEN_PREFIX, "") else null
-
 
     private fun getTokenBody(token: String, secret: Key): Claims {
         return try {


### PR DESCRIPTION
## 💡 개요
`OAuthTokenProvider`, `JwtTokenProvider`는 parseToken()이라는 토큰을 파싱하는
과정의 **공통 로직의 보일러 플레이트코드**를 가지고 있었습니다.

TokenParser 클래스로 **책임을 분리함**으로써 문제를 해결했습니다.
+ 집나간 OauthCode 엔티티 클래스를 다시 불러들였습니다.

## 📃 작업내용
- TokenParser 클래스로 parseToken 작업 처리
- RefreshOAuthCodeService tokenParser 의존
- SignInService tokenParser 의존

```kt
@Component
class TokenParser(
    private val jwtProperties: JwtProperties,
    private val authDetailsService: AuthDetailsService
) {

    fun parseToken(token: String): String? =
        if (token.startsWith(JwtTokenProvider.TOKEN_PREFIX)) token.replace(JwtTokenProvider.TOKEN_PREFIX, "") else null

    fun exactEmailFromRefreshToken(refresh: String): String {
        return getTokenSubject(refresh, jwtProperties.refreshSecret)
    }

    fun exactEmailFromOauthRefreshToken(refresh: String): String =
        getTokenSubject(refresh, jwtProperties.oauthSecret)

    fun exactClientIdFromOauthRefreshToken(refresh: String): String =
        getTokenBody(refresh, jwtProperties.oauthSecret)["clientId"].toString()

    fun authentication(token: String): Authentication {
        val userDetails = authDetailsService.loadUserByUsername(getTokenSubject(token, jwtProperties.accessSecret))
        return UsernamePasswordAuthenticationToken(userDetails, "", userDetails.authorities)
    }

...
}
```


## 🔀 변경사항
- OauthCode 엔티티 경로
- OAuthToken, JwtTokenProvider

## 🙋‍♂️ 질문사항

## ⚗️ 사용법

## 🎸 기타
