### PR TITLE
🔀 :: CREATED 상태의 STUDENT만 조회하도록 변경

### DIFF
--- a/src/main/kotlin/com/msg/gauth/domain/user/repository/CustomUserRepositoryImpl.kt
+++ b/src/main/kotlin/com/msg/gauth/domain/user/repository/CustomUserRepositoryImpl.kt
@@ -3,6 +3,7 @@ package com.msg.gauth.domain.user.repository
 import com.msg.gauth.domain.user.QUser.user
 import com.msg.gauth.domain.user.User
 import com.msg.gauth.domain.user.enums.UserRole
+import com.msg.gauth.domain.user.enums.UserState
 import com.querydsl.core.types.dsl.BooleanExpression
 import com.querydsl.jpa.impl.JPAQueryFactory
 import org.springframework.stereotype.Repository
@@ -18,6 +19,7 @@ class CustomUserRepositoryImpl(
                 .where(
                     gradeEq(grade),
                     classNumEq(classNum),
+                    stateEq(UserState.CREATED),
                     keywordLike(keyword),
                     roleContains(UserRole.ROLE_STUDENT)
                 )
@@ -36,4 +38,6 @@ class CustomUserRepositoryImpl(
     private fun roleContains(userRole: UserRole): BooleanExpression =
         user.roles.contains(userRole)
 
+    private fun stateEq(userState: UserState): BooleanExpression =
+        user.state.eq(userState)
 }


### PR DESCRIPTION
## 💡 개요
어드민 API중 하나인 학생 전체 조회 기능이 데이터베이스의 PENDING 상태인 유저의 역할이 ROLE_STUDENT로 부여되어 학년 반 번호가 존재하지 않는 로우가 같이 조회되어 NPE가 발생하는 문제가 생겼습니다. 따라서 CREATED 상태의 STUDENT만 조회하도록 했습니다
## 📃 작업내용
학생 조회 QueryDSL 구현 클래스에 stateEq 함수를 추가하여 조회 쿼리에 조건이 하나 추가하였습니다