### PR TITLE
🔀 :: 232 UserRole 엔티티 추가

### DIFF
--- a/src/main/kotlin/com/msg/gauth/domain/auth/service/SignUpService.kt
+++ b/src/main/kotlin/com/msg/gauth/domain/auth/service/SignUpService.kt
@@ -3,7 +3,7 @@ package com.msg.gauth.domain.auth.service
 import com.msg.gauth.domain.auth.presentation.dto.request.SignUpDto
 import com.msg.gauth.domain.email.repository.EmailAuthRepository
 import com.msg.gauth.domain.user.User
-import com.msg.gauth.domain.user.enums.UserRole
+import com.msg.gauth.domain.user.enums.UserRoleType
 import com.msg.gauth.domain.user.enums.UserState
 import com.msg.gauth.domain.user.exception.EmailNotVerifiedException
 import com.msg.gauth.domain.user.repository.UserRepository
@@ -25,7 +25,7 @@ class SignUpService(
         val user = User(
             email = signUpDto.email,
             password = passwordEncoder.encode(signUpDto.password),
-            roles = mutableListOf(UserRole.ROLE_STUDENT),
+            roles = mutableListOf(UserRoleType.ROLE_STUDENT),
             state = UserState.PENDING,
             profileUrl = null
         )

--- a/src/main/kotlin/com/msg/gauth/domain/auth/service/SignUpService.kt
+++ b/src/main/kotlin/com/msg/gauth/domain/auth/service/SignUpService.kt
@@ -3,10 +3,12 @@ package com.msg.gauth.domain.auth.service
 import com.msg.gauth.domain.auth.presentation.dto.request.SignUpDto
 import com.msg.gauth.domain.email.repository.EmailAuthRepository
 import com.msg.gauth.domain.user.User
+import com.msg.gauth.domain.user.UserRole
 import com.msg.gauth.domain.user.enums.UserRoleType
 import com.msg.gauth.domain.user.enums.UserState
 import com.msg.gauth.domain.user.exception.EmailNotVerifiedException
 import com.msg.gauth.domain.user.repository.UserRepository
+import com.msg.gauth.domain.user.repository.UserRoleRepository
 import com.msg.gauth.global.annotation.service.TransactionalService
 import com.msg.gauth.global.exception.exceptions.DuplicateEmailException
 import org.springframework.security.crypto.password.PasswordEncoder
@@ -14,6 +16,7 @@ import org.springframework.security.crypto.password.PasswordEncoder
 @TransactionalService
 class SignUpService(
     private val userRepository: UserRepository,
+    private val userRoleRepository: UserRoleRepository
     private val passwordEncoder: PasswordEncoder,
     private val emailAuthRepository: EmailAuthRepository
 ) {
@@ -39,6 +42,20 @@ class SignUpService(
         }
 
         emailAuthRepository.delete(emailAuth)
-        return userRepository.save(user).id
+
+        val savedUser = userRepository.save(user)
+
+        saveUserRole(user)
+
+        return savedUser.id
+    }
+
+    private fun saveUserRole(user: User) {
+        val userRole = UserRole(
+            user = user,
+            userRoleType = UserRoleType.ROLE_STUDENT
+        )
+
+        userRoleRepository.save(userRole)
     }
 }

--- a/src/main/kotlin/com/msg/gauth/domain/auth/service/SignUpService.kt
+++ b/src/main/kotlin/com/msg/gauth/domain/auth/service/SignUpService.kt
@@ -16,7 +16,7 @@ import org.springframework.security.crypto.password.PasswordEncoder
 @TransactionalService
 class SignUpService(
     private val userRepository: UserRepository,
-    private val userRoleRepository: UserRoleRepository
+    private val userRoleRepository: UserRoleRepository,
     private val passwordEncoder: PasswordEncoder,
     private val emailAuthRepository: EmailAuthRepository
 ) {
@@ -25,10 +25,10 @@ class SignUpService(
             emailAuthRepository.deleteById(signUpDto.email)
             throw DuplicateEmailException()
         }
+
         val user = User(
             email = signUpDto.email,
             password = passwordEncoder.encode(signUpDto.password),
-            roles = mutableListOf(UserRoleType.ROLE_STUDENT),
             state = UserState.PENDING,
             profileUrl = null
         )

--- a/src/main/kotlin/com/msg/gauth/domain/user/User.kt
+++ b/src/main/kotlin/com/msg/gauth/domain/user/User.kt
@@ -33,10 +33,14 @@ class User(
     @Column(nullable = true)
     val num: Int? = null,
 
+    @Deprecated("'roles' is deprecated. use instead of 'userRoles'")
     @Enumerated(EnumType.STRING)
     @ElementCollection(fetch = FetchType.EAGER)
     @CollectionTable(name = "UserRole", joinColumns = [JoinColumn(name = "id")])
     val roles: MutableList<UserRoleType> = mutableListOf(),
+
+    @OneToMany(mappedBy = "user", fetch = FetchType.LAZY)
+    val userRoles: List<UserRole>,
 
     @Enumerated(EnumType.STRING)
     val state: UserState,

--- a/src/main/kotlin/com/msg/gauth/domain/user/User.kt
+++ b/src/main/kotlin/com/msg/gauth/domain/user/User.kt
@@ -1,7 +1,7 @@
 package com.msg.gauth.domain.user
 
 import com.msg.gauth.domain.user.enums.Gender
-import com.msg.gauth.domain.user.enums.UserRole
+import com.msg.gauth.domain.user.enums.UserRoleType
 import com.msg.gauth.domain.user.enums.UserState
 import com.msg.gauth.global.entity.BaseIdEntity
 import javax.persistence.*
@@ -36,7 +36,7 @@ class User(
     @Enumerated(EnumType.STRING)
     @ElementCollection(fetch = FetchType.EAGER)
     @CollectionTable(name = "UserRole", joinColumns = [JoinColumn(name = "id")])
-    val roles: MutableList<UserRole> = mutableListOf(),
+    val roles: MutableList<UserRoleType> = mutableListOf(),
 
     @Enumerated(EnumType.STRING)
     val state: UserState,

--- a/src/main/kotlin/com/msg/gauth/domain/user/User.kt
+++ b/src/main/kotlin/com/msg/gauth/domain/user/User.kt
@@ -39,8 +39,8 @@ class User(
     @CollectionTable(name = "UserRole", joinColumns = [JoinColumn(name = "id")])
     val roles: MutableList<UserRoleType> = mutableListOf(),
 
-    @OneToMany(mappedBy = "user", fetch = FetchType.LAZY)
-    val userRoles: List<UserRole>,
+    @OneToMany(mappedBy = "user", fetch = FetchType.LAZY, cascade = [CascadeType.PERSIST])
+    val userRoles: List<UserRole> = mutableListOf(),
 
     @Enumerated(EnumType.STRING)
     val state: UserState,

--- a/src/main/kotlin/com/msg/gauth/domain/user/User.kt
+++ b/src/main/kotlin/com/msg/gauth/domain/user/User.kt
@@ -39,7 +39,7 @@ class User(
     @CollectionTable(name = "UserRole", joinColumns = [JoinColumn(name = "id")])
     val roles: MutableList<UserRoleType> = mutableListOf(),
 
-    @OneToMany(mappedBy = "user", fetch = FetchType.LAZY, cascade = [CascadeType.PERSIST])
+    @OneToMany(mappedBy = "user", fetch = FetchType.LAZY, cascade = [CascadeType.PERSIST], orphanRemoval = true)
     val userRoles: List<UserRole> = mutableListOf(),
 
     @Enumerated(EnumType.STRING)

--- a/src/main/kotlin/com/msg/gauth/domain/user/UserRole.kt
+++ b/src/main/kotlin/com/msg/gauth/domain/user/UserRole.kt
@@ -5,7 +5,7 @@ import javax.persistence.*
 import com.msg.gauth.domain.user.enums.UserRoleType
 
 @Entity
-class UserRoleEntity(
+class UserRole(
     override val id: Long = 0L,
 
     @ManyToOne(fetch = FetchType.LAZY)

--- a/src/main/kotlin/com/msg/gauth/domain/user/UserRoleEntity.kt
+++ b/src/main/kotlin/com/msg/gauth/domain/user/UserRoleEntity.kt
@@ -1,0 +1,18 @@
+package com.msg.gauth.domain.user
+
+import com.msg.gauth.global.entity.BaseIdEntity
+import javax.persistence.*
+import com.msg.gauth.domain.user.enums.UserRole
+
+@Entity
+class UserRoleEntity(
+    override val id: Long = 0L,
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    val user: User,
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "user_role", nullable = false)
+    val userRole: UserRole
+) : BaseIdEntity(id)

--- a/src/main/kotlin/com/msg/gauth/domain/user/UserRoleEntity.kt
+++ b/src/main/kotlin/com/msg/gauth/domain/user/UserRoleEntity.kt
@@ -2,7 +2,7 @@ package com.msg.gauth.domain.user
 
 import com.msg.gauth.global.entity.BaseIdEntity
 import javax.persistence.*
-import com.msg.gauth.domain.user.enums.UserRole
+import com.msg.gauth.domain.user.enums.UserRoleType
 
 @Entity
 class UserRoleEntity(
@@ -14,5 +14,5 @@ class UserRoleEntity(
 
     @Enumerated(EnumType.STRING)
     @Column(name = "user_role", nullable = false)
-    val userRole: UserRole
+    val userRoleType: UserRoleType
 ) : BaseIdEntity(id)

--- a/src/main/kotlin/com/msg/gauth/domain/user/enums/UserRoleType.kt
+++ b/src/main/kotlin/com/msg/gauth/domain/user/enums/UserRoleType.kt
@@ -2,7 +2,7 @@ package com.msg.gauth.domain.user.enums
 
 import org.springframework.security.core.GrantedAuthority
 
-enum class UserRole : GrantedAuthority {
+enum class UserRoleType : GrantedAuthority {
     ROLE_STUDENT, ROLE_TEACHER, ROLE_ADMIN, ROLE_GRADUATE;
 
     override fun getAuthority(): String =

--- a/src/main/kotlin/com/msg/gauth/domain/user/presentation/dto/request/AcceptTeacherReqDto.kt
+++ b/src/main/kotlin/com/msg/gauth/domain/user/presentation/dto/request/AcceptTeacherReqDto.kt
@@ -2,7 +2,7 @@ package com.msg.gauth.domain.user.presentation.dto.request
 
 import com.msg.gauth.domain.user.User
 import com.msg.gauth.domain.user.enums.Gender
-import com.msg.gauth.domain.user.enums.UserRole
+import com.msg.gauth.domain.user.enums.UserRoleType
 import com.msg.gauth.domain.user.enums.UserState
 import javax.validation.constraints.NotBlank
 
@@ -19,7 +19,7 @@ data class AcceptTeacherReqDto(
             name = user.name,
             password = user.password,
             gender = this.gender,
-            roles = mutableListOf(UserRole.ROLE_TEACHER),
+            roles = mutableListOf(UserRoleType.ROLE_TEACHER),
             state = UserState.CREATED,
             profileUrl = user.profileUrl,
             wrongPasswordCount = user.wrongPasswordCount,

--- a/src/main/kotlin/com/msg/gauth/domain/user/presentation/dto/request/AcceptUserReqDto.kt
+++ b/src/main/kotlin/com/msg/gauth/domain/user/presentation/dto/request/AcceptUserReqDto.kt
@@ -2,14 +2,14 @@ package com.msg.gauth.domain.user.presentation.dto.request
 
 import com.msg.gauth.domain.user.User
 import com.msg.gauth.domain.user.enums.Gender
-import com.msg.gauth.domain.user.enums.UserRole
+import com.msg.gauth.domain.user.enums.UserRoleType
 import com.msg.gauth.domain.user.enums.UserState
 import javax.validation.constraints.NotBlank
 import javax.validation.constraints.NotNull
 
 data class AcceptUserReqDto(
     @field:NotNull
-    val userRole: UserRole,
+    val userRoleType: UserRoleType,
     @field:NotBlank
     val name: String,
     @field:NotNull
@@ -28,7 +28,7 @@ data class AcceptUserReqDto(
             grade = grade,
             classNum = classNum,
             num = num,
-            roles = mutableListOf(UserRole.ROLE_STUDENT),
+            roles = mutableListOf(UserRoleType.ROLE_STUDENT),
             state = UserState.CREATED,
             profileUrl = user.profileUrl,
             wrongPasswordCount = user.wrongPasswordCount,
@@ -46,7 +46,7 @@ data class AcceptUserReqDto(
             grade = grade,
             classNum = classNum,
             num = num,
-            roles = mutableListOf(UserRole.ROLE_TEACHER),
+            roles = mutableListOf(UserRoleType.ROLE_TEACHER),
             state = UserState.CREATED,
             profileUrl = user.profileUrl
         )
@@ -62,7 +62,7 @@ data class AcceptUserReqDto(
             grade = grade,
             classNum = classNum,
             num = num,
-            roles = mutableListOf(UserRole.ROLE_GRADUATE),
+            roles = mutableListOf(UserRoleType.ROLE_GRADUATE),
             state = UserState.CREATED,
             profileUrl = user.profileUrl
         )

--- a/src/main/kotlin/com/msg/gauth/domain/user/presentation/dto/request/AcceptedUserRequest.kt
+++ b/src/main/kotlin/com/msg/gauth/domain/user/presentation/dto/request/AcceptedUserRequest.kt
@@ -1,11 +1,11 @@
 package com.msg.gauth.domain.user.presentation.dto.request
 
-import com.msg.gauth.domain.user.enums.UserRole
+import com.msg.gauth.domain.user.enums.UserRoleType
 import org.springframework.web.bind.annotation.RequestParam
 
 data class AcceptedUserRequest(
     @RequestParam(required = false) val grade: Int = 0,
     @RequestParam(required = false) val classNum: Int = 0,
     @RequestParam(required = false) val keyword: String = "",
-    @RequestParam(required = false) val role: UserRole = UserRole.ROLE_STUDENT
+    @RequestParam(required = false) val role: UserRoleType = UserRoleType.ROLE_STUDENT
 )

--- a/src/main/kotlin/com/msg/gauth/domain/user/presentation/dto/response/GetMyRolesResDto.kt
+++ b/src/main/kotlin/com/msg/gauth/domain/user/presentation/dto/response/GetMyRolesResDto.kt
@@ -1,7 +1,7 @@
 package com.msg.gauth.domain.user.presentation.dto.response
 
-import com.msg.gauth.domain.user.enums.UserRole
+import com.msg.gauth.domain.user.enums.UserRoleType
 
 data class GetMyRolesResDto(
-    val roles: List<UserRole>
+    val roles: List<UserRoleType>
 )

--- a/src/main/kotlin/com/msg/gauth/domain/user/repository/CustomUserRepositoryImpl.kt
+++ b/src/main/kotlin/com/msg/gauth/domain/user/repository/CustomUserRepositoryImpl.kt
@@ -2,7 +2,7 @@ package com.msg.gauth.domain.user.repository
 
 import com.msg.gauth.domain.user.QUser.user
 import com.msg.gauth.domain.user.User
-import com.msg.gauth.domain.user.enums.UserRole
+import com.msg.gauth.domain.user.enums.UserRoleType
 import com.msg.gauth.domain.user.enums.UserState
 import com.querydsl.core.types.dsl.BooleanExpression
 import com.querydsl.jpa.impl.JPAQueryFactory
@@ -21,7 +21,7 @@ class CustomUserRepositoryImpl(
                     classNumEq(classNum),
                     stateEq(UserState.CREATED),
                     keywordLike(keyword),
-                    roleContains(UserRole.ROLE_STUDENT)
+                    roleContains(UserRoleType.ROLE_STUDENT)
                 )
                 .fetch()
     }
@@ -35,8 +35,8 @@ class CustomUserRepositoryImpl(
     private fun keywordLike(keyword: String): BooleanExpression? =
         if(keyword.isNotEmpty()) user.name.like("%${keyword}%") else null
 
-    private fun roleContains(userRole: UserRole): BooleanExpression =
-        user.roles.contains(userRole)
+    private fun roleContains(userRoleType: UserRoleType): BooleanExpression =
+        user.roles.contains(userRoleType)
 
     private fun stateEq(userState: UserState): BooleanExpression =
         user.state.eq(userState)

--- a/src/main/kotlin/com/msg/gauth/domain/user/repository/UserRepository.kt
+++ b/src/main/kotlin/com/msg/gauth/domain/user/repository/UserRepository.kt
@@ -1,7 +1,7 @@
 package com.msg.gauth.domain.user.repository
 
 import com.msg.gauth.domain.user.User
-import com.msg.gauth.domain.user.enums.UserRole
+import com.msg.gauth.domain.user.enums.UserRoleType
 import com.msg.gauth.domain.user.enums.UserState
 import org.springframework.data.domain.Page
 import org.springframework.data.domain.Pageable
@@ -17,8 +17,8 @@ interface UserRepository: JpaRepository<User, Long>, CustomUserRepository {
     fun findAllByState(state: UserState): List<User>
     fun findAllByState(state: UserState, pageable: Pageable): Page<User>
     fun findByIdAndState(id: Long, roles: UserState): User?
-    fun findAllByRolesContaining(role: UserRole): List<User>
+    fun findAllByRolesContaining(role: UserRoleType): List<User>
 
     @Query("select user from User user where user.id = :id and user.state = :state and user.roles = :roles")
-    fun findByIdAndStateAndRoles(id: Long, state: UserState, roles: MutableList<UserRole>): User?
+    fun findByIdAndStateAndRoles(id: Long, state: UserState, roles: MutableList<UserRoleType>): User?
 }

--- a/src/main/kotlin/com/msg/gauth/domain/user/repository/UserRoleRepository.kt
+++ b/src/main/kotlin/com/msg/gauth/domain/user/repository/UserRoleRepository.kt
@@ -1,0 +1,7 @@
+package com.msg.gauth.domain.user.repository
+
+import com.msg.gauth.domain.user.UserRole
+import org.springframework.data.repository.CrudRepository
+
+interface UserRoleRepository:  CrudRepository<UserRole, Long>{
+}

--- a/src/main/kotlin/com/msg/gauth/domain/user/service/AcceptStudentSignUpService.kt
+++ b/src/main/kotlin/com/msg/gauth/domain/user/service/AcceptStudentSignUpService.kt
@@ -1,6 +1,6 @@
 package com.msg.gauth.domain.user.service
 
-import com.msg.gauth.domain.user.enums.UserRole
+import com.msg.gauth.domain.user.enums.UserRoleType
 import com.msg.gauth.domain.user.enums.UserState
 import com.msg.gauth.domain.user.exception.UserNotFoundException
 import com.msg.gauth.domain.user.presentation.dto.request.AcceptStudentReqDto
@@ -12,7 +12,7 @@ class AcceptStudentSignUpService(
     val userRepository: UserRepository
 ) {
     fun execute(acceptedStudentReqDto: AcceptStudentReqDto) {
-        val user = userRepository.findByIdAndStateAndRoles(acceptedStudentReqDto.id, UserState.PENDING, mutableListOf(UserRole.ROLE_STUDENT))
+        val user = userRepository.findByIdAndStateAndRoles(acceptedStudentReqDto.id, UserState.PENDING, mutableListOf(UserRoleType.ROLE_STUDENT))
             ?: throw UserNotFoundException()
         userRepository.save(acceptedStudentReqDto.toEntity(user))
     }

--- a/src/main/kotlin/com/msg/gauth/domain/user/service/AcceptTeacherSignUpService.kt
+++ b/src/main/kotlin/com/msg/gauth/domain/user/service/AcceptTeacherSignUpService.kt
@@ -1,7 +1,7 @@
 package com.msg.gauth.domain.user.service
 
 import com.msg.gauth.domain.user.User
-import com.msg.gauth.domain.user.enums.UserRole
+import com.msg.gauth.domain.user.enums.UserRoleType
 import com.msg.gauth.domain.user.enums.UserState
 import com.msg.gauth.domain.user.exception.UserNotFoundException
 import com.msg.gauth.domain.user.presentation.dto.request.AcceptTeacherReqDto
@@ -14,7 +14,7 @@ class AcceptTeacherSignUpService(
 ) {
 
     fun execute(acceptTeacherReqDto: AcceptTeacherReqDto) {
-        val user: User = userRepository.findByIdAndStateAndRoles(acceptTeacherReqDto.id, UserState.PENDING, mutableListOf(UserRole.ROLE_TEACHER))
+        val user: User = userRepository.findByIdAndStateAndRoles(acceptTeacherReqDto.id, UserState.PENDING, mutableListOf(UserRoleType.ROLE_TEACHER))
             ?: throw UserNotFoundException()
 
         userRepository.save(acceptTeacherReqDto.toEntity(user))

--- a/src/main/kotlin/com/msg/gauth/domain/user/service/AcceptUserSignUpService.kt
+++ b/src/main/kotlin/com/msg/gauth/domain/user/service/AcceptUserSignUpService.kt
@@ -1,7 +1,7 @@
 package com.msg.gauth.domain.user.service
 
 import com.msg.gauth.domain.client.exception.BadUserRoleRequestException
-import com.msg.gauth.domain.user.enums.UserRole
+import com.msg.gauth.domain.user.enums.UserRoleType
 import com.msg.gauth.domain.user.enums.UserState
 import com.msg.gauth.domain.user.exception.UserNotFoundException
 import com.msg.gauth.domain.user.presentation.dto.request.AcceptUserReqDto
@@ -14,10 +14,10 @@ class AcceptUserSignUpService(
 ) {
 
     fun execute(id: Long, acceptUserReqDto: AcceptUserReqDto) =
-        when(acceptUserReqDto.userRole){
-            UserRole.ROLE_STUDENT -> acceptStudent(id, acceptUserReqDto)
-            UserRole.ROLE_TEACHER -> acceptTeacher(id, acceptUserReqDto)
-            UserRole.ROLE_GRADUATE -> acceptGraduate(id, acceptUserReqDto)
+        when(acceptUserReqDto.userRoleType){
+            UserRoleType.ROLE_STUDENT -> acceptStudent(id, acceptUserReqDto)
+            UserRoleType.ROLE_TEACHER -> acceptTeacher(id, acceptUserReqDto)
+            UserRoleType.ROLE_GRADUATE -> acceptGraduate(id, acceptUserReqDto)
             else -> throw BadUserRoleRequestException()
         }
 

--- a/src/main/kotlin/com/msg/gauth/domain/user/service/GetAcceptedUsersService.kt
+++ b/src/main/kotlin/com/msg/gauth/domain/user/service/GetAcceptedUsersService.kt
@@ -1,6 +1,6 @@
 package com.msg.gauth.domain.user.service
 
-import com.msg.gauth.domain.user.enums.UserRole
+import com.msg.gauth.domain.user.enums.UserRoleType
 import com.msg.gauth.domain.user.presentation.dto.request.AcceptedUserRequest
 import com.msg.gauth.domain.user.presentation.dto.response.SingleAcceptedUserResDto
 import com.msg.gauth.domain.user.repository.UserRepository
@@ -12,7 +12,7 @@ class GetAcceptedUsersService(
 ) {
     fun execute(request: AcceptedUserRequest): List<SingleAcceptedUserResDto> =
         when(request.role) {
-            UserRole.ROLE_STUDENT -> userRepository.search(request.grade, request.classNum, request.keyword)
+            UserRoleType.ROLE_STUDENT -> userRepository.search(request.grade, request.classNum, request.keyword)
             else -> userRepository.findAllByRolesContaining(request.role)
         }.map { SingleAcceptedUserResDto(it) }
 }

--- a/src/main/kotlin/com/msg/gauth/domain/user/service/GetMyRolesService.kt
+++ b/src/main/kotlin/com/msg/gauth/domain/user/service/GetMyRolesService.kt
@@ -9,5 +9,5 @@ class GetMyRolesService(
     private val userUtil: UserUtil
 ) {
     fun execute(): GetMyRolesResDto =
-        GetMyRolesResDto(userUtil.fetchCurrentUser().roles)
+        GetMyRolesResDto(userUtil.fetchCurrentUser().userRoles.map { it.userRoleType })
 }

--- a/src/main/kotlin/com/msg/gauth/domain/user/service/GetMyRolesService.kt
+++ b/src/main/kotlin/com/msg/gauth/domain/user/service/GetMyRolesService.kt
@@ -8,6 +8,7 @@ import com.msg.gauth.global.annotation.service.ReadOnlyService
 class GetMyRolesService(
     private val userUtil: UserUtil
 ) {
+    // TODO: DB 이전 완료 시 roles -> userRoles.map { it.userRoleType }로 변경
     fun execute(): GetMyRolesResDto =
         GetMyRolesResDto(userUtil.fetchCurrentUser().userRoles.map { it.userRoleType })
 }


### PR DESCRIPTION
## 💡 개요
회원가입 수락된 유저들을 검색 및 조회하는 기능을 개선하기 위해 UserRole Enum을 ```@ElementCollection```이 아닌 @OneToMany
## 📃 작업내용
User와 UserRoleType을 담고 있는 UserRole 엔티티 추가
User와 UserRole을 양방향 관계로 매핑
부모 엔티티 영속 시 자식 엔티티도 같이 영속 옵션 추가 및 부모 엔티티 삭제 시 자식엔티티도 같이 삭제 옵션 추가
## 🔀 변경사항
UserRole Enum의 이름을 UserRoleType으로 변경하였습니다