### PR TITLE
🔀 :: 테이블명 중복 제거

### DIFF
--- a/src/main/kotlin/com/msg/gauth/domain/user/User.kt
+++ b/src/main/kotlin/com/msg/gauth/domain/user/User.kt
@@ -36,7 +36,7 @@ class User(
     @Deprecated("'roles' is deprecated. use instead of 'userRoles'")
     @Enumerated(EnumType.STRING)
     @ElementCollection(fetch = FetchType.EAGER)
-    @CollectionTable(name = "UserRole", joinColumns = [JoinColumn(name = "id")])
+    @CollectionTable(name = "roles", joinColumns = [JoinColumn(name = "id")])
     val roles: MutableList<UserRoleType> = mutableListOf(),
 
     @OneToMany(mappedBy = "user", fetch = FetchType.LAZY, cascade = [CascadeType.PERSIST], orphanRemoval = true)


### PR DESCRIPTION
## 💡 개요
유저의 역할을 담은 컬렉션 테이블과 엔티티의 이름이 중복되어 엔티티 테이블이 생성되지 않는 문제가 발생했습니다
## 📃 작업내용
컬렉션 테이블의 이름을 roles로 변경하였습니다
## 🎸 기타
이전의 pr에서 이름이 중복되는걸 깜빡하고 안바꿨었네요..
