### PR TITLE
🔀 :: UserRole 엔티티 대신 collection table 사용

### DIFF
--- a/src/main/kotlin/com/msg/gauth/domain/user/service/GetMyRolesService.kt
+++ b/src/main/kotlin/com/msg/gauth/domain/user/service/GetMyRolesService.kt
@@ -10,5 +10,5 @@ class GetMyRolesService(
 ) {
     // TODO: DB 이전 완료 시 roles -> userRoles.map { it.userRoleType }로 변경
     fun execute(): GetMyRolesResDto =
-        GetMyRolesResDto(userUtil.fetchCurrentUser().userRoles.map { it.userRoleType })
+        GetMyRolesResDto(userUtil.fetchCurrentUser().roles)
 }


### PR DESCRIPTION
## 💡 개요
유저의 역할을 가져오는 api에서 아직 적용하지 않은 UserRole 엔티티를 사용하고 있어 아직 사용중인 collectionTable을 사용하도록 변경하였습니다