### PR TITLE
🔀 :: 258 add exporter dependency

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -40,7 +40,7 @@ dependencies {
     testImplementation(Dependencies.SPRING_STARTER_TEST)
     testImplementation(Dependencies.SPRING_SECURITY_TEST)
     implementation(Dependencies.SPRING_AOP)
-
+    implementation(Dependencies.SPRING_ACTUATOR)
 
     // kotlin
     implementation(Dependencies.JACKSON_MODULE_KOTLIN)
@@ -73,6 +73,9 @@ dependencies {
     implementation(Dependencies.QUERY_DSL)
     implementation(Dependencies.QUERY_DSL_APT)
     kapt(Dependencies.QUERY_DSL_APT)
+
+    // prometheus
+    implementation(Dependencies.PROMETHEUS_MICROMETER)
 }
 
 

--- a/buildSrc/src/main/kotlin/Dependencies.kt
+++ b/buildSrc/src/main/kotlin/Dependencies.kt
@@ -16,6 +16,7 @@ object Dependencies {
     const val SPRING_STARTER_TEST = "org.springframework.boot:spring-boot-starter-test"
     const val SPRING_SECURITY_TEST = "org.springframework.security:spring-security-test"
     const val SPRING_AOP = "org.springframework.boot:spring-boot-starter-aop"
+    const val SPRING_ACTUATOR = "org.springframework.boot:spring-boot-starter-actuator"
 
     // jackson
     const val JACKSON_MODULE_KOTLIN = "com.fasterxml.jackson.module:jackson-module-kotlin"
@@ -43,4 +44,6 @@ object Dependencies {
     const val QUERY_DSL = "com.querydsl:querydsl-jpa:${DependencyVersions.QUERY_DSL_VERSION}"
     const val QUERY_DSL_APT = "com.querydsl:querydsl-apt:${DependencyVersions.QUERY_DSL_APT_VERSION}:jpa"
 
+    // prometheus
+    const val PROMETHEUS_MICROMETER = "io.micrometer:micrometer-registry-prometheus"
 }

--- a/src/main/kotlin/com/msg/gauth/global/security/SecurityConfig.kt
+++ b/src/main/kotlin/com/msg/gauth/global/security/SecurityConfig.kt
@@ -4,9 +4,12 @@ import com.fasterxml.jackson.databind.ObjectMapper
 import com.msg.gauth.global.security.config.FilterConfig
 import com.msg.gauth.global.security.jwt.JwtTokenProvider
 import com.msg.gauth.global.security.jwt.TokenParser
+import org.springframework.boot.actuate.autoconfigure.security.servlet.EndpointRequest
+import org.springframework.boot.actuate.autoconfigure.security.servlet.SecurityRequestMatchersManagementContextConfiguration
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 import org.springframework.http.HttpMethod
+import org.springframework.security.config.Customizer.withDefaults
 import org.springframework.security.config.annotation.web.builders.HttpSecurity
 import org.springframework.security.config.http.SessionCreationPolicy
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder
@@ -14,6 +17,7 @@ import org.springframework.security.crypto.password.PasswordEncoder
 import org.springframework.security.web.SecurityFilterChain
 import org.springframework.security.web.util.matcher.RequestMatcher
 import org.springframework.web.cors.CorsUtils
+
 
 @Configuration
 class SecurityConfig(
@@ -87,6 +91,11 @@ class SecurityConfig(
             //image
             .antMatchers(HttpMethod.POST, "/image").authenticated()
             .antMatchers(HttpMethod.DELETE, "/image").authenticated()
+
+            // Actuator
+            .antMatchers(HttpMethod.GET, "/actuator/health").hasRole("ADMIN")
+            .antMatchers(HttpMethod.GET, "/actuator/info").hasRole("ADMIN")
+            .antMatchers(HttpMethod.GET, "/actuator/prometheus").hasRole("ADMIN")
 
             .anyRequest().denyAll()
             .and()

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -65,3 +65,20 @@ jwt:
   accessSecret: ${JWT_ACCESS}
   refreshSecret: ${JWT_REFRESH}
   oauthSecret: ${JWT_OAUTH}
+
+management:
+  endpoints:
+    enabled-by-default: false
+    web:
+      exposure:
+        include: health,info,prometheus
+
+  endpoint:
+    health:
+      enabled: true
+
+    info:
+      enabled: true
+
+    prometheus:
+      enabled: true


### PR DESCRIPTION
## 💡 개요
prometheus로 정보를 수집하기 위한 exporter를 spirng actuator를 통해 설정해주었습니다
## 📃 작업내용
* spring actuator dependency 추가
* prometheus 엔드포인트를 사용하기 위한 micrometer-registry-prometheus dependency 추가
* application.yml에 health, info, prometheus 엔드포인트를 사용하기 위해서 enabled 처리 및 HTTP를 통해 내보내기 위한 설정 추가
* security config에 해당 엔드포인트들 핸들링 처리

## 🙋‍♂️ 질문사항
security config에 일단 antMatchers 메서드를 통해 접근을 핸들링했는데 actuator는 처음이라 이렇게 처리하는게 맞을까 싶네요 다른 더 좋은 방법이 있다면 알려주세요!!