### PR TITLE
🔀  :: golang를 사용한 accessToken 갱신 스크립트

### DIFF
--- a/renew_jwt.go
+++ b/renew_jwt.go
@@ -3,7 +3,6 @@ package main
 import (
 	"bytes"
 	"encoding/json"
-	"fmt"
 	"io"
 	"net/http"
 	"os"
@@ -28,7 +27,6 @@ func main() {
 		Password: os.Getenv("GAUTH_PASSWORD"),
 	}
 
-	fmt.Println(url)
 	reqBody, _ := json.Marshal(user)
 
 	req, err := http.NewRequest("POST", url, bytes.NewBuffer(reqBody))
@@ -45,8 +43,6 @@ func main() {
 	if err != nil {
 		panic(err)
 	}
-
-	fmt.Println(string(body))
 
 	var token Token
 	err = json.Unmarshal(body, &token)

--- a/renew_jwt.go
+++ b/renew_jwt.go
@@ -1,0 +1,61 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+)
+
+type User struct {
+	Email    string `json:"email"`
+	Password string `json:"password"`
+}
+
+type Token struct {
+	AccessToken string `json:"accessToken"`
+}
+
+func main() {
+	client := &http.Client{}
+
+	url := os.Getenv("GAUTH_SERVER_URL")
+
+	user := User{
+		Email:    os.Getenv("GAUTH_USER_NAME"),
+		Password: os.Getenv("GAUTH_PASSWORD"),
+	}
+
+	fmt.Println(url)
+	reqBody, _ := json.Marshal(user)
+
+	req, err := http.NewRequest("POST", url, bytes.NewBuffer(reqBody))
+	req.Header.Set("Content-Type", "application/json")
+
+	res, err := client.Do(req)
+	if err != nil {
+		panic(err)
+	}
+
+	defer res.Body.Close()
+
+	body, err := io.ReadAll(res.Body)
+	if err != nil {
+		panic(err)
+	}
+
+	fmt.Println(string(body))
+
+	var token Token
+	err = json.Unmarshal(body, &token)
+	if err != nil {
+		panic(err)
+	}
+
+	err = os.WriteFile("../jwt.txt", []byte(token.AccessToken), 0777)
+	if err != nil {
+		panic(err)
+	}
+}


### PR DESCRIPTION
## 💡 개요
golang으로 prometheus의 토큰을 자동으로 갱신해줄 스크립트를 작성했어요
## 📃 작업내용
gauth 서버에 로그인요청을 보내어 accessToken을 응답으로 받아 파일에 쓰도록 스크립트를 작성했어요
## 🔀 변경사항
private EC2의 .bashrc에 환경변수로 ```GAUTH_SERVER_URL```, ```GAUTH_USER_NAME```, ```GAUTH_PASSWORD```추가해주어야해요
## 🙋‍♂️ 질문사항
* Golang을 실행시킬 환경을 Docker로 세팅을 해보려 하는데 그냥 저희가 docker image pull을 하듯이 ec2에도 pull해서 golang을 설치하면 되는걸까요?
* jwt를 담을 파일의 접근 권한을 설정하는 것은 일단은 모든 사용자가 읽고, 쓰고, 실행할 수 있는 777로 설정해 두었는데 이건 어떻게 조정하면 좋을까요?
## 🎸 기타
실행 흐름은 노션에 정리해 두었어요!! 링크는 [여기](https://www.notion.so/matsougeum/prometheus-jwt-109f2231801d48efaf4a708fc0be31a2?pvs=4)에 있어요
**아무나 Golang을 아신다면 리뷰를..**
사실 Golang이 스크립트로 실행이 잘 될지도 모르겠긴 합니다..