### PR TITLE
🔀 :: 회원가입시 이메일 중복 검사

### DIFF
--- a/src/main/kotlin/com/msg/gauth/domain/auth/presentation/AuthController.kt
+++ b/src/main/kotlin/com/msg/gauth/domain/auth/presentation/AuthController.kt
@@ -1,11 +1,8 @@
 package com.msg.gauth.domain.auth.presentation
 
-import com.msg.gauth.domain.auth.presentation.dto.request.SignUpDto
-import com.msg.gauth.domain.auth.presentation.dto.request.SignInRequestDto
+import com.msg.gauth.domain.auth.presentation.dto.request.*
 import com.msg.gauth.domain.auth.presentation.dto.response.RefreshResponseDto
 import com.msg.gauth.domain.auth.service.*
-import com.msg.gauth.domain.auth.presentation.dto.request.InitPasswordRequestDto
-import com.msg.gauth.domain.auth.presentation.dto.request.UpdatePasswordRequestDto
 import com.msg.gauth.domain.auth.presentation.dto.response.SignInResponseDto
 import com.msg.gauth.domain.auth.presentation.dto.response.SignUpImageResDto
 import com.msg.gauth.domain.auth.service.InitPasswordService
@@ -24,7 +21,8 @@ class AuthController(
     private val signUpService: SignUpService,
     private val initPasswordService: InitPasswordService,
     private val signUpImageUploadService: SignUpImageUploadService,
-    private val updatePasswordService: UpdatePasswordService
+    private val updatePasswordService: UpdatePasswordService,
+    private val signUpEmailVerificationService: SignUpEmailVerificationService
 ) {
     @PatchMapping
     fun refresh(@RequestHeader("RefreshToken") refreshToken: String): ResponseEntity<RefreshResponseDto> {
@@ -68,4 +66,11 @@ class AuthController(
         updatePasswordService.execute(updatePasswordRequestDto)
         return ResponseEntity.noContent().build()
     }
+
+    @GetMapping
+    fun signUpEmailVerification(@RequestParam email: String): ResponseEntity<Void> {
+        signUpEmailVerificationService.execute(email)
+        return ResponseEntity.ok().build()
+    }
+
 }

--- a/src/main/kotlin/com/msg/gauth/domain/auth/service/SignUpEmailVerificationService.kt
+++ b/src/main/kotlin/com/msg/gauth/domain/auth/service/SignUpEmailVerificationService.kt
@@ -1,0 +1,15 @@
+package com.msg.gauth.domain.auth.service
+
+import com.msg.gauth.domain.user.repository.UserRepository
+import com.msg.gauth.global.annotation.service.ReadOnlyService
+import com.msg.gauth.global.exception.exceptions.DuplicateEmailException
+
+@ReadOnlyService
+class SignUpEmailVerificationService(
+    private val userRepository: UserRepository
+) {
+    fun execute(email: String) {
+        if (userRepository.existsByEmail(email))
+            throw DuplicateEmailException()
+    }
+}

--- a/src/main/kotlin/com/msg/gauth/global/security/SecurityConfig.kt
+++ b/src/main/kotlin/com/msg/gauth/global/security/SecurityConfig.kt
@@ -50,6 +50,7 @@ class SecurityConfig(
             .antMatchers(HttpMethod.PATCH, "/auth/image").permitAll()
             .antMatchers(HttpMethod.DELETE, "/auth/image").permitAll()
             .antMatchers(HttpMethod.PATCH, "/auth/password").authenticated()
+            .antMatchers(HttpMethod.GET, "/auth").permitAll()
 
             // Email
             .antMatchers(HttpMethod.POST, "/email").permitAll()


### PR DESCRIPTION
## 💡 배경 및 개요

회원가입을 할 때 이메일 인증을 존재하는 이메일에도 인증메일을 보내는 문제를 해결하기 위해 존재하는 이메일인지 검증한 후에 인증 메일을 보낼 수 있도록 api를 추가하였습니다

Resolves: #335 

## 📃 작업내용

존재하는 이메일인지 검증하는 signUpEmailVerification api를 추가하였습니다

## ✅ PR 체크리스트

- [x] 이 작업으로 인해 변경이 필요한 문서가 변경되었나요? (e.g. `.env`, `노션`, `README`)
- [x] 이 작업을 하고나서 공유해야할 팀원들에게 공유되었나요? (e.g. `"API 개발 완료됐어요"`, `"환경값 추가되었어요"`)
- [x] 작업한 코드가 정상적으로 동작하나요?
- [x] Merge 대상 브랜치가 올바른가요?
- [x] PR과 관련 없는 작업이 있지는 않나요?
- [ ] 이 작업으로 인해 발생한 변경 사항이 Resource 서버에도 반영되었나요?

## 🎸 기타