### PR TITLE
🔀 :: 레디스 캐시 적용

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -45,7 +45,6 @@ dependencies {
     implementation(Dependencies.SPRING_ACTUATOR)
     implementation(Dependencies.SPRING_CACHE)
 
-
     // kotlin
     implementation(Dependencies.JACKSON_MODULE_KOTLIN)
     implementation(Dependencies.KOTLIN_REFLET)

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -43,6 +43,8 @@ dependencies {
     testImplementation(Dependencies.SPRING_SECURITY_TEST)
     implementation(Dependencies.SPRING_AOP)
     implementation(Dependencies.SPRING_ACTUATOR)
+    implementation(Dependencies.SPRING_CACHE)
+
 
     // kotlin
     implementation(Dependencies.JACKSON_MODULE_KOTLIN)

--- a/buildSrc/src/main/kotlin/Dependencies.kt
+++ b/buildSrc/src/main/kotlin/Dependencies.kt
@@ -17,6 +17,7 @@ object Dependencies {
     const val SPRING_SECURITY_TEST = "org.springframework.security:spring-security-test"
     const val SPRING_AOP = "org.springframework.boot:spring-boot-starter-aop"
     const val SPRING_ACTUATOR = "org.springframework.boot:spring-boot-starter-actuator"
+    const val SPRING_CACHE = "org.springframework.boot:spring-boot-starter-cache"
 
     // jackson
     const val JACKSON_MODULE_KOTLIN = "com.fasterxml.jackson.module:jackson-module-kotlin"

--- a/src/main/kotlin/com/msg/gauth/GauthBackendApplication.kt
+++ b/src/main/kotlin/com/msg/gauth/GauthBackendApplication.kt
@@ -3,10 +3,12 @@ package com.msg.gauth
 import org.springframework.boot.autoconfigure.SpringBootApplication
 import org.springframework.boot.context.properties.ConfigurationPropertiesScan
 import org.springframework.boot.runApplication
+import org.springframework.cache.annotation.EnableCaching
 import java.util.*
 
 @SpringBootApplication
 @ConfigurationPropertiesScan
+@EnableCaching
 class GauthBackendApplication
 
 fun main(args: Array<String>) {

--- a/src/main/kotlin/com/msg/gauth/domain/admin/service/ExcelParsingService.kt
+++ b/src/main/kotlin/com/msg/gauth/domain/admin/service/ExcelParsingService.kt
@@ -13,13 +13,14 @@ import org.apache.poi.ss.usermodel.Sheet
 import org.apache.poi.ss.usermodel.Workbook
 import org.apache.poi.xssf.usermodel.XSSFWorkbook
 import org.apache.tika.Tika
+import org.springframework.cache.annotation.CacheEvict
 import org.springframework.web.multipart.MultipartFile
 
 @TransactionalService
 class ExcelParsingService(
     private val userRepository: UserRepository,
 ) {
-
+    @CacheEvict(value = ["AcceptedUser"], allEntries = true, cacheManager = "userCacheManager")
     fun execute(file: MultipartFile) {
         val tika = Tika()
         val detect = tika.detect(file.bytes)

--- a/src/main/kotlin/com/msg/gauth/domain/admin/service/ExcelParsingService.kt
+++ b/src/main/kotlin/com/msg/gauth/domain/admin/service/ExcelParsingService.kt
@@ -20,7 +20,7 @@ import org.springframework.web.multipart.MultipartFile
 class ExcelParsingService(
     private val userRepository: UserRepository,
 ) {
-    @CacheEvict(value = ["AcceptedUser"], allEntries = true, cacheManager = "userCacheManager")
+    @CacheEvict(value = ["AcceptedUsers"], allEntries = true, cacheManager = "userCacheManager")
     fun execute(file: MultipartFile) {
         val tika = Tika()
         val detect = tika.detect(file.bytes)

--- a/src/main/kotlin/com/msg/gauth/domain/admin/service/ExcelParsingService.kt
+++ b/src/main/kotlin/com/msg/gauth/domain/admin/service/ExcelParsingService.kt
@@ -20,7 +20,7 @@ import org.springframework.web.multipart.MultipartFile
 class ExcelParsingService(
     private val userRepository: UserRepository,
 ) {
-    @CacheEvict(value = ["AcceptedUsers"], allEntries = true, cacheManager = "userCacheManager")
+    @CacheEvict(value = ["AcceptedUsers"], allEntries = true, cacheManager = "redisCacheManager")
     fun execute(file: MultipartFile) {
         val tika = Tika()
         val detect = tika.detect(file.bytes)

--- a/src/main/kotlin/com/msg/gauth/domain/client/presentation/dto/response/SingleClientResDto.kt
+++ b/src/main/kotlin/com/msg/gauth/domain/client/presentation/dto/response/SingleClientResDto.kt
@@ -1,17 +1,18 @@
 package com.msg.gauth.domain.client.presentation.dto.response
 
+import com.fasterxml.jackson.annotation.JsonCreator
+import com.fasterxml.jackson.annotation.JsonProperty
 import com.msg.gauth.domain.client.Client
 import com.msg.gauth.domain.client.enums.ServiceScope
 
-data class SingleClientResDto(
-    val id: Long,
-    val clientId: String,
-    val serviceName: String,
-    val serviceUri: String,
-    val serviceScope: ServiceScope,
-    val serviceImgUrl: String
+data class SingleClientResDto @JsonCreator constructor(
+    @JsonProperty("id") val id: Long,
+    @JsonProperty("clientId") val clientId: String,
+    @JsonProperty("serviceName") val serviceName: String,
+    @JsonProperty("serviceUri") val serviceUri: String,
+    @JsonProperty("serviceScope") val serviceScope: ServiceScope,
+    @JsonProperty("serviceImgUrl") val serviceImgUrl: String
 ) {
-
     constructor(client: Client) : this(
         id = client.id,
         clientId = client.clientId,

--- a/src/main/kotlin/com/msg/gauth/domain/client/service/DeleteClientService.kt
+++ b/src/main/kotlin/com/msg/gauth/domain/client/service/DeleteClientService.kt
@@ -5,6 +5,7 @@ import com.msg.gauth.domain.client.exception.UserNotMatchException
 import com.msg.gauth.domain.client.repository.ClientRepository
 import com.msg.gauth.domain.user.util.UserUtil
 import com.msg.gauth.global.annotation.service.TransactionalService
+import org.springframework.cache.annotation.CacheEvict
 import org.springframework.data.repository.findByIdOrNull
 
 @TransactionalService
@@ -13,6 +14,7 @@ class DeleteClientService(
     private val userUtil: UserUtil,
 ) {
 
+    @CacheEvict(value= ["Clients"], allEntries = true, cacheManager = "clientCacheManager")
     fun execute(id: Long) {
         val client = clientRepository.findByIdOrNull(id)
             ?: throw ClientNotFindException()

--- a/src/main/kotlin/com/msg/gauth/domain/client/service/DeleteClientService.kt
+++ b/src/main/kotlin/com/msg/gauth/domain/client/service/DeleteClientService.kt
@@ -14,7 +14,7 @@ class DeleteClientService(
     private val userUtil: UserUtil,
 ) {
 
-    @CacheEvict(value = ["Clients"], allEntries = true, cacheManager = "clientCacheManager")
+    @CacheEvict(value = ["Clients"], allEntries = true, cacheManager = "redisCacheManager")
     fun execute(id: Long) {
         val client = clientRepository.findByIdOrNull(id)
             ?: throw ClientNotFindException()

--- a/src/main/kotlin/com/msg/gauth/domain/client/service/DeleteClientService.kt
+++ b/src/main/kotlin/com/msg/gauth/domain/client/service/DeleteClientService.kt
@@ -14,7 +14,7 @@ class DeleteClientService(
     private val userUtil: UserUtil,
 ) {
 
-    @CacheEvict(value= ["Clients"], allEntries = true, cacheManager = "clientCacheManager")
+    @CacheEvict(value = ["Clients"], allEntries = true, cacheManager = "clientCacheManager")
     fun execute(id: Long) {
         val client = clientRepository.findByIdOrNull(id)
             ?: throw ClientNotFindException()

--- a/src/main/kotlin/com/msg/gauth/domain/client/service/DeleteClientsService.kt
+++ b/src/main/kotlin/com/msg/gauth/domain/client/service/DeleteClientsService.kt
@@ -11,7 +11,7 @@ class DeleteClientsService(
     private val userUtil: UserUtil
 ) {
 
-    @CacheEvict(value = ["Clients"], allEntries = true, cacheManager = "clientCacheManager")
+    @CacheEvict(value = ["Clients"], allEntries = true, cacheManager = "redisCacheManager")
     fun execute(ids: List<Long>) {
         val user = userUtil.fetchCurrentUser()
 

--- a/src/main/kotlin/com/msg/gauth/domain/client/service/DeleteClientsService.kt
+++ b/src/main/kotlin/com/msg/gauth/domain/client/service/DeleteClientsService.kt
@@ -3,6 +3,7 @@ package com.msg.gauth.domain.client.service
 import com.msg.gauth.domain.client.repository.ClientRepository
 import com.msg.gauth.domain.user.util.UserUtil
 import com.msg.gauth.global.annotation.service.TransactionalService
+import org.springframework.cache.annotation.CacheEvict
 
 @TransactionalService
 class DeleteClientsService(
@@ -10,6 +11,7 @@ class DeleteClientsService(
     private val userUtil: UserUtil
 ) {
 
+    @CacheEvict(value= ["Clients"], allEntries = true, cacheManager = "clientCacheManager")
     fun execute(ids: List<Long>) {
         val user = userUtil.fetchCurrentUser()
 

--- a/src/main/kotlin/com/msg/gauth/domain/client/service/DeleteClientsService.kt
+++ b/src/main/kotlin/com/msg/gauth/domain/client/service/DeleteClientsService.kt
@@ -11,7 +11,7 @@ class DeleteClientsService(
     private val userUtil: UserUtil
 ) {
 
-    @CacheEvict(value= ["Clients"], allEntries = true, cacheManager = "clientCacheManager")
+    @CacheEvict(value = ["Clients"], allEntries = true, cacheManager = "clientCacheManager")
     fun execute(ids: List<Long>) {
         val user = userUtil.fetchCurrentUser()
 

--- a/src/main/kotlin/com/msg/gauth/domain/client/service/GetAllClientsService.kt
+++ b/src/main/kotlin/com/msg/gauth/domain/client/service/GetAllClientsService.kt
@@ -11,7 +11,7 @@ class GetAllClientsService(
     private val clientRepository: ClientRepository
 ) {
 
-    @Cacheable(value = ["Clients"], cacheManager = "clientCacheManager")
+    @Cacheable(value = ["Clients"], cacheManager = "redisCacheManager")
     fun execute(): List<SingleClientResDto> =
         clientRepository.findByServiceScope(ServiceScope.PUBLIC)
             .map { SingleClientResDto(it) }

--- a/src/main/kotlin/com/msg/gauth/domain/client/service/GetAllClientsService.kt
+++ b/src/main/kotlin/com/msg/gauth/domain/client/service/GetAllClientsService.kt
@@ -4,12 +4,14 @@ import com.msg.gauth.domain.client.enums.ServiceScope
 import com.msg.gauth.domain.client.presentation.dto.response.SingleClientResDto
 import com.msg.gauth.domain.client.repository.ClientRepository
 import com.msg.gauth.global.annotation.service.ReadOnlyService
+import org.springframework.cache.annotation.Cacheable
 
 @ReadOnlyService
 class GetAllClientsService(
     private val clientRepository: ClientRepository
 ) {
 
+    @Cacheable(value = ["Clients"], cacheManager = "clientCacheManager")
     fun execute(): List<SingleClientResDto> =
         clientRepository.findByServiceScope(ServiceScope.PUBLIC)
             .map { SingleClientResDto(it) }

--- a/src/main/kotlin/com/msg/gauth/domain/client/service/RegisterClientService.kt
+++ b/src/main/kotlin/com/msg/gauth/domain/client/service/RegisterClientService.kt
@@ -14,7 +14,7 @@ class RegisterClientService(
     private val userUtil: UserUtil,
 ) {
 
-    @CacheEvict(value= ["Clients"], allEntries = true, cacheManager = "clientCacheManager")
+    @CacheEvict(value = ["Clients"], allEntries = true, cacheManager = "clientCacheManager")
     fun execute(clientRegisterDto: ClientRegisterReqDto): ClientRegisterResDto {
         val (clientSecret, clientId) = createUUID() to createUUID()
 

--- a/src/main/kotlin/com/msg/gauth/domain/client/service/RegisterClientService.kt
+++ b/src/main/kotlin/com/msg/gauth/domain/client/service/RegisterClientService.kt
@@ -14,7 +14,7 @@ class RegisterClientService(
     private val userUtil: UserUtil,
 ) {
 
-    @CacheEvict(value = ["Clients"], allEntries = true, cacheManager = "clientCacheManager")
+    @CacheEvict(value = ["Clients"], allEntries = true, cacheManager = "redisCacheManager")
     fun execute(clientRegisterDto: ClientRegisterReqDto): ClientRegisterResDto {
         val (clientSecret, clientId) = createUUID() to createUUID()
 

--- a/src/main/kotlin/com/msg/gauth/domain/client/service/RegisterClientService.kt
+++ b/src/main/kotlin/com/msg/gauth/domain/client/service/RegisterClientService.kt
@@ -5,6 +5,7 @@ import com.msg.gauth.domain.client.presentation.dto.response.ClientRegisterResDt
 import com.msg.gauth.domain.client.repository.ClientRepository
 import com.msg.gauth.domain.user.util.UserUtil
 import com.msg.gauth.global.annotation.service.TransactionalService
+import org.springframework.cache.annotation.CacheEvict
 import java.util.UUID
 
 @TransactionalService
@@ -13,6 +14,7 @@ class RegisterClientService(
     private val userUtil: UserUtil,
 ) {
 
+    @CacheEvict(value= ["Clients"], allEntries = true, cacheManager = "clientCacheManager")
     fun execute(clientRegisterDto: ClientRegisterReqDto): ClientRegisterResDto {
         val (clientSecret, clientId) = createUUID() to createUUID()
 

--- a/src/main/kotlin/com/msg/gauth/domain/client/service/UpdateAnyClientService.kt
+++ b/src/main/kotlin/com/msg/gauth/domain/client/service/UpdateAnyClientService.kt
@@ -13,7 +13,7 @@ class UpdateAnyClientService(
     private val clientRepository: ClientRepository
 ) {
 
-    @CacheEvict(value= ["Clients"], allEntries = true, cacheManager = "clientCacheManager")
+    @CacheEvict(value = ["Clients"], allEntries = true, cacheManager = "clientCacheManager")
     fun execute(id: Long, clientUpdateReqDto: ClientUpdateReqDto) {
         val client: Client = clientRepository.findByIdOrNull(id)
             ?: throw ClientNotFindException()

--- a/src/main/kotlin/com/msg/gauth/domain/client/service/UpdateAnyClientService.kt
+++ b/src/main/kotlin/com/msg/gauth/domain/client/service/UpdateAnyClientService.kt
@@ -5,6 +5,7 @@ import com.msg.gauth.domain.client.exception.ClientNotFindException
 import com.msg.gauth.domain.client.presentation.dto.request.ClientUpdateReqDto
 import com.msg.gauth.domain.client.repository.ClientRepository
 import com.msg.gauth.global.annotation.service.TransactionalService
+import org.springframework.cache.annotation.CacheEvict
 import org.springframework.data.repository.findByIdOrNull
 
 @TransactionalService
@@ -12,6 +13,7 @@ class UpdateAnyClientService(
     private val clientRepository: ClientRepository
 ) {
 
+    @CacheEvict(value= ["Clients"], allEntries = true, cacheManager = "clientCacheManager")
     fun execute(id: Long, clientUpdateReqDto: ClientUpdateReqDto) {
         val client: Client = clientRepository.findByIdOrNull(id)
             ?: throw ClientNotFindException()

--- a/src/main/kotlin/com/msg/gauth/domain/client/service/UpdateAnyClientService.kt
+++ b/src/main/kotlin/com/msg/gauth/domain/client/service/UpdateAnyClientService.kt
@@ -13,7 +13,7 @@ class UpdateAnyClientService(
     private val clientRepository: ClientRepository
 ) {
 
-    @CacheEvict(value = ["Clients"], allEntries = true, cacheManager = "clientCacheManager")
+    @CacheEvict(value = ["Clients"], allEntries = true, cacheManager = "redisCacheManager")
     fun execute(id: Long, clientUpdateReqDto: ClientUpdateReqDto) {
         val client: Client = clientRepository.findByIdOrNull(id)
             ?: throw ClientNotFindException()

--- a/src/main/kotlin/com/msg/gauth/domain/client/service/UpdateClientService.kt
+++ b/src/main/kotlin/com/msg/gauth/domain/client/service/UpdateClientService.kt
@@ -13,7 +13,7 @@ class UpdateClientService(
     private val userUtil: UserUtil
 ) {
 
-    @CacheEvict(value= ["Clients"], allEntries = true, cacheManager = "clientCacheManager")
+    @CacheEvict(value = ["Clients"], allEntries = true, cacheManager = "clientCacheManager")
     fun updateClient(id: Long, clientUpdateReqDto: ClientUpdateReqDto) {
         val client = clientRepository.findByIdAndCreatedBy(id, userUtil.fetchCurrentUser())
             ?: throw ClientNotFindException()

--- a/src/main/kotlin/com/msg/gauth/domain/client/service/UpdateClientService.kt
+++ b/src/main/kotlin/com/msg/gauth/domain/client/service/UpdateClientService.kt
@@ -5,6 +5,7 @@ import com.msg.gauth.domain.client.presentation.dto.request.ClientUpdateReqDto
 import com.msg.gauth.domain.client.repository.ClientRepository
 import com.msg.gauth.domain.user.util.UserUtil
 import com.msg.gauth.global.annotation.service.TransactionalService
+import org.springframework.cache.annotation.CacheEvict
 
 @TransactionalService
 class UpdateClientService(
@@ -12,6 +13,7 @@ class UpdateClientService(
     private val userUtil: UserUtil
 ) {
 
+    @CacheEvict(value= ["Clients"], allEntries = true, cacheManager = "clientCacheManager")
     fun updateClient(id: Long, clientUpdateReqDto: ClientUpdateReqDto) {
         val client = clientRepository.findByIdAndCreatedBy(id, userUtil.fetchCurrentUser())
             ?: throw ClientNotFindException()

--- a/src/main/kotlin/com/msg/gauth/domain/client/service/UpdateClientService.kt
+++ b/src/main/kotlin/com/msg/gauth/domain/client/service/UpdateClientService.kt
@@ -13,7 +13,7 @@ class UpdateClientService(
     private val userUtil: UserUtil
 ) {
 
-    @CacheEvict(value = ["Clients"], allEntries = true, cacheManager = "clientCacheManager")
+    @CacheEvict(value = ["Clients"], allEntries = true, cacheManager = "redisCacheManager")
     fun updateClient(id: Long, clientUpdateReqDto: ClientUpdateReqDto) {
         val client = clientRepository.findByIdAndCreatedBy(id, userUtil.fetchCurrentUser())
             ?: throw ClientNotFindException()

--- a/src/main/kotlin/com/msg/gauth/domain/user/presentation/dto/response/SingleAcceptedUserResDto.kt
+++ b/src/main/kotlin/com/msg/gauth/domain/user/presentation/dto/response/SingleAcceptedUserResDto.kt
@@ -1,15 +1,17 @@
 package com.msg.gauth.domain.user.presentation.dto.response
 
+import com.fasterxml.jackson.annotation.JsonCreator
+import com.fasterxml.jackson.annotation.JsonProperty
 import com.msg.gauth.domain.user.User
 
-data class SingleAcceptedUserResDto(
-    val id: Long,
-    val name: String,
-    val email: String,
-    val grade: Int?,
-    val classNum: Int?,
-    val num: Int?,
-    val profileUrl: String?
+data class SingleAcceptedUserResDto @JsonCreator constructor(
+    @JsonProperty("id") val id: Long,
+    @JsonProperty("name") val name: String,
+    @JsonProperty("email") val email: String,
+    @JsonProperty("grade") val grade: Int?,
+    @JsonProperty("classNum") val classNum: Int?,
+    @JsonProperty("num") val num: Int?,
+    @JsonProperty("profileUrl") val profileUrl: String?
 ) {
 
     constructor(user: User) : this(

--- a/src/main/kotlin/com/msg/gauth/domain/user/service/AcceptUserSignUpService.kt
+++ b/src/main/kotlin/com/msg/gauth/domain/user/service/AcceptUserSignUpService.kt
@@ -15,7 +15,7 @@ class AcceptUserSignUpService(
     private val userRoleRepository: UserRoleRepository
 ) {
 
-    @CacheEvict(value = ["AcceptedUser"], allEntries = true, cacheManager = "redisCacheManager")
+    @CacheEvict(value = ["AcceptedUsers"], allEntries = true, cacheManager = "redisCacheManager")
     fun execute(id: Long, acceptUserReqDto: AcceptUserReqDto) {
         val user = userRepository.findByIdAndState(id, UserState.PENDING)
             ?: throw UserNotFoundException()

--- a/src/main/kotlin/com/msg/gauth/domain/user/service/AcceptUserSignUpService.kt
+++ b/src/main/kotlin/com/msg/gauth/domain/user/service/AcceptUserSignUpService.kt
@@ -15,7 +15,7 @@ class AcceptUserSignUpService(
     private val userRoleRepository: UserRoleRepository
 ) {
 
-    @CacheEvict(value = ["AcceptedUser"], allEntries = true, cacheManager = "userCacheManager")
+    @CacheEvict(value = ["AcceptedUser"], allEntries = true, cacheManager = "redisCacheManager")
     fun execute(id: Long, acceptUserReqDto: AcceptUserReqDto) {
         val user = userRepository.findByIdAndState(id, UserState.PENDING)
             ?: throw UserNotFoundException()

--- a/src/main/kotlin/com/msg/gauth/domain/user/service/AcceptUserSignUpService.kt
+++ b/src/main/kotlin/com/msg/gauth/domain/user/service/AcceptUserSignUpService.kt
@@ -7,6 +7,7 @@ import com.msg.gauth.domain.user.presentation.dto.request.AcceptUserReqDto
 import com.msg.gauth.domain.user.repository.UserRepository
 import com.msg.gauth.domain.user.repository.UserRoleRepository
 import com.msg.gauth.global.annotation.service.TransactionalService
+import org.springframework.cache.annotation.CacheEvict
 
 @TransactionalService
 class AcceptUserSignUpService(
@@ -14,6 +15,7 @@ class AcceptUserSignUpService(
     private val userRoleRepository: UserRoleRepository
 ) {
 
+    @CacheEvict(value = ["AcceptedUser"], allEntries = true, cacheManager = "userCacheManager")
     fun execute(id: Long, acceptUserReqDto: AcceptUserReqDto) {
         val user = userRepository.findByIdAndState(id, UserState.PENDING)
             ?: throw UserNotFoundException()

--- a/src/main/kotlin/com/msg/gauth/domain/user/service/GetAcceptedUsersService.kt
+++ b/src/main/kotlin/com/msg/gauth/domain/user/service/GetAcceptedUsersService.kt
@@ -12,7 +12,7 @@ class GetAcceptedUsersService(
     private val userRepository: UserRepository,
 ) {
 
-    @Cacheable(value = ["AcceptedUser"], cacheManager = "userCacheManager")
+    @Cacheable(value = ["AcceptedUser"], cacheManager = "redisCacheManager")
     fun execute(request: AcceptedUserRequest): List<SingleAcceptedUserResDto> =
         when (request.role) {
             UserRoleType.ROLE_STUDENT -> userRepository.search(request.grade, request.classNum, request.keyword)

--- a/src/main/kotlin/com/msg/gauth/domain/user/service/GetAcceptedUsersService.kt
+++ b/src/main/kotlin/com/msg/gauth/domain/user/service/GetAcceptedUsersService.kt
@@ -5,11 +5,14 @@ import com.msg.gauth.domain.user.presentation.dto.request.AcceptedUserRequest
 import com.msg.gauth.domain.user.presentation.dto.response.SingleAcceptedUserResDto
 import com.msg.gauth.domain.user.repository.UserRepository
 import com.msg.gauth.global.annotation.service.ReadOnlyService
+import org.springframework.cache.annotation.Cacheable
 
 @ReadOnlyService
 class GetAcceptedUsersService(
     private val userRepository: UserRepository,
 ) {
+
+    @Cacheable(value = ["AcceptedUser"], cacheManager = "userCacheManager")
     fun execute(request: AcceptedUserRequest): List<SingleAcceptedUserResDto> =
         when (request.role) {
             UserRoleType.ROLE_STUDENT -> userRepository.search(request.grade, request.classNum, request.keyword)

--- a/src/main/kotlin/com/msg/gauth/domain/user/service/GetAcceptedUsersService.kt
+++ b/src/main/kotlin/com/msg/gauth/domain/user/service/GetAcceptedUsersService.kt
@@ -12,7 +12,7 @@ class GetAcceptedUsersService(
     private val userRepository: UserRepository,
 ) {
 
-    @Cacheable(value = ["AcceptedUser"], condition = "#request.grade == 0 && #request.classNum == 0 && #request.keyword.equals('') && #request.role.equals('ROLE_STUDENT')", 
+    @Cacheable(value = ["AcceptedUser"], condition = "#request.grade == 0 && #request.classNum == 0 && #request.keyword.equals('') && #request.role.equals('ROLE_STUDENT')", cacheManager = "redisCacheManager")
     fun execute(request: AcceptedUserRequest): List<SingleAcceptedUserResDto> =
         when (request.role) {
             UserRoleType.ROLE_STUDENT -> userRepository.search(request.grade, request.classNum, request.keyword)

--- a/src/main/kotlin/com/msg/gauth/domain/user/service/GetAcceptedUsersService.kt
+++ b/src/main/kotlin/com/msg/gauth/domain/user/service/GetAcceptedUsersService.kt
@@ -12,7 +12,7 @@ class GetAcceptedUsersService(
     private val userRepository: UserRepository,
 ) {
 
-    @Cacheable(value = ["AcceptedUser"], condition = "#request.grade == 0 && #request.classNum == 0 && #request.keyword.equals('') && #request.role.equals('ROLE_STUDENT')", cacheManager = "redisCacheManager")
+    @Cacheable(value = ["AcceptedUsers"], condition = "#request.grade == 0 && #request.classNum == 0 && #request.keyword.equals('') && #request.role.equals('ROLE_STUDENT')", cacheManager = "redisCacheManager")
     fun execute(request: AcceptedUserRequest): List<SingleAcceptedUserResDto> =
         when (request.role) {
             UserRoleType.ROLE_STUDENT -> userRepository.search(request.grade, request.classNum, request.keyword)

--- a/src/main/kotlin/com/msg/gauth/domain/user/service/GetAcceptedUsersService.kt
+++ b/src/main/kotlin/com/msg/gauth/domain/user/service/GetAcceptedUsersService.kt
@@ -12,7 +12,7 @@ class GetAcceptedUsersService(
     private val userRepository: UserRepository,
 ) {
 
-    @Cacheable(value = ["AcceptedUser"], condition = "#request.grade = 0 && #request.classNum = 0 && #request.keyword.equals('') && #request.role.equals('ROLE_STUDENT')", cacheManager = "redisCacheManager")
+    @Cacheable(value = ["AcceptedUser"], condition = "#request.grade == 0 && #request.classNum == 0 && #request.keyword.equals('') && #request.role.equals('ROLE_STUDENT')", 
     fun execute(request: AcceptedUserRequest): List<SingleAcceptedUserResDto> =
         when (request.role) {
             UserRoleType.ROLE_STUDENT -> userRepository.search(request.grade, request.classNum, request.keyword)

--- a/src/main/kotlin/com/msg/gauth/domain/user/service/GetAcceptedUsersService.kt
+++ b/src/main/kotlin/com/msg/gauth/domain/user/service/GetAcceptedUsersService.kt
@@ -12,7 +12,7 @@ class GetAcceptedUsersService(
     private val userRepository: UserRepository,
 ) {
 
-    @Cacheable(value = ["AcceptedUser"], cacheManager = "redisCacheManager")
+    @Cacheable(value = ["AcceptedUser"], condition = "#request.grade = 0 && #request.classNum = 0 && #request.keyword.equals('') && #request.role.equals('ROLE_STUDENT')", cacheManager = "redisCacheManager")
     fun execute(request: AcceptedUserRequest): List<SingleAcceptedUserResDto> =
         when (request.role) {
             UserRoleType.ROLE_STUDENT -> userRepository.search(request.grade, request.classNum, request.keyword)

--- a/src/main/kotlin/com/msg/gauth/global/redis/RedisCacheConfig.kt
+++ b/src/main/kotlin/com/msg/gauth/global/redis/RedisCacheConfig.kt
@@ -1,0 +1,37 @@
+package com.msg.gauth.global.redis
+
+import org.springframework.cache.CacheManager
+import org.springframework.cache.annotation.EnableCaching
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import org.springframework.data.redis.cache.RedisCacheConfiguration
+import org.springframework.data.redis.cache.RedisCacheManager
+import org.springframework.data.redis.connection.RedisConnectionFactory
+import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer
+import org.springframework.data.redis.serializer.RedisSerializationContext
+import org.springframework.data.redis.serializer.StringRedisSerializer
+import java.time.Duration
+
+@Configuration
+@EnableCaching
+class RedisCacheConfig {
+
+    @Bean
+    fun clientCacheManager(factory: RedisConnectionFactory?): CacheManager {
+        val cacheConfig = RedisCacheConfiguration.defaultCacheConfig()
+            .serializeKeysWith(RedisSerializationContext.SerializationPair.fromSerializer(StringRedisSerializer()))
+            .serializeValuesWith(
+                RedisSerializationContext.SerializationPair.fromSerializer(
+                    GenericJackson2JsonRedisSerializer()
+                )
+            )
+            .entryTtl(Duration.ofMinutes(1L))
+
+        return RedisCacheManager
+            .RedisCacheManagerBuilder
+            .fromConnectionFactory(factory!!)
+            .cacheDefaults(cacheConfig)
+            .build()
+    }
+
+}

--- a/src/main/kotlin/com/msg/gauth/global/redis/RedisCacheConfig.kt
+++ b/src/main/kotlin/com/msg/gauth/global/redis/RedisCacheConfig.kt
@@ -34,4 +34,22 @@ class RedisCacheConfig {
             .build()
     }
 
+    @Bean
+    fun userCacheManager(factory: RedisConnectionFactory?): CacheManager {
+        val cacheConfig = RedisCacheConfiguration.defaultCacheConfig()
+            .serializeKeysWith(RedisSerializationContext.SerializationPair.fromSerializer(StringRedisSerializer()))
+            .serializeValuesWith(
+                RedisSerializationContext.SerializationPair.fromSerializer(
+                    GenericJackson2JsonRedisSerializer()
+                )
+            )
+            .entryTtl(Duration.ofMinutes(1L))
+
+        return RedisCacheManager
+            .RedisCacheManagerBuilder
+            .fromConnectionFactory(factory!!)
+            .cacheDefaults(cacheConfig)
+            .build()
+    }
+
 }

--- a/src/main/kotlin/com/msg/gauth/global/redis/RedisCacheConfig.kt
+++ b/src/main/kotlin/com/msg/gauth/global/redis/RedisCacheConfig.kt
@@ -4,6 +4,7 @@ import org.springframework.cache.CacheManager
 import org.springframework.cache.annotation.EnableCaching
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
+import org.springframework.context.annotation.Primary
 import org.springframework.data.redis.cache.RedisCacheConfiguration
 import org.springframework.data.redis.cache.RedisCacheManager
 import org.springframework.data.redis.connection.RedisConnectionFactory
@@ -17,6 +18,7 @@ import java.time.Duration
 class RedisCacheConfig {
 
     @Bean
+    @Primary
     fun clientCacheManager(factory: RedisConnectionFactory?): CacheManager {
         val cacheConfig = RedisCacheConfiguration.defaultCacheConfig()
             .serializeKeysWith(RedisSerializationContext.SerializationPair.fromSerializer(StringRedisSerializer()))

--- a/src/main/kotlin/com/msg/gauth/global/redis/RedisCacheConfig.kt
+++ b/src/main/kotlin/com/msg/gauth/global/redis/RedisCacheConfig.kt
@@ -45,7 +45,7 @@ class RedisCacheConfig {
                     GenericJackson2JsonRedisSerializer()
                 )
             )
-            .entryTtl(Duration.ofMinutes(1L))
+            .entryTtl(Duration.ofMinutes(10L))
 
         return RedisCacheManager
             .RedisCacheManagerBuilder

--- a/src/main/kotlin/com/msg/gauth/global/redis/RedisCacheConfig.kt
+++ b/src/main/kotlin/com/msg/gauth/global/redis/RedisCacheConfig.kt
@@ -27,7 +27,7 @@ class RedisCacheConfig {
                     GenericJackson2JsonRedisSerializer()
                 )
             )
-            .entryTtl(Duration.ofMinutes(1L))
+            .entryTtl(Duration.ofMinutes(10))
 
         return RedisCacheManager
             .RedisCacheManagerBuilder
@@ -45,7 +45,7 @@ class RedisCacheConfig {
                     GenericJackson2JsonRedisSerializer()
                 )
             )
-            .entryTtl(Duration.ofMinutes(10L))
+            .entryTtl(Duration.ofMinutes(10))
 
         return RedisCacheManager
             .RedisCacheManagerBuilder

--- a/src/main/kotlin/com/msg/gauth/global/redis/RedisCacheConfig.kt
+++ b/src/main/kotlin/com/msg/gauth/global/redis/RedisCacheConfig.kt
@@ -53,5 +53,4 @@ class RedisCacheConfig {
             .cacheDefaults(cacheConfig)
             .build()
     }
-
 }

--- a/src/main/kotlin/com/msg/gauth/global/redis/RedisCacheConfig.kt
+++ b/src/main/kotlin/com/msg/gauth/global/redis/RedisCacheConfig.kt
@@ -4,7 +4,6 @@ import org.springframework.cache.CacheManager
 import org.springframework.cache.annotation.EnableCaching
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
-import org.springframework.context.annotation.Primary
 import org.springframework.data.redis.cache.RedisCacheConfiguration
 import org.springframework.data.redis.cache.RedisCacheManager
 import org.springframework.data.redis.connection.RedisConnectionFactory

--- a/src/main/kotlin/com/msg/gauth/global/redis/RedisCacheConfig.kt
+++ b/src/main/kotlin/com/msg/gauth/global/redis/RedisCacheConfig.kt
@@ -18,26 +18,7 @@ import java.time.Duration
 class RedisCacheConfig {
 
     @Bean
-    @Primary
-    fun clientCacheManager(factory: RedisConnectionFactory?): CacheManager {
-        val cacheConfig = RedisCacheConfiguration.defaultCacheConfig()
-            .serializeKeysWith(RedisSerializationContext.SerializationPair.fromSerializer(StringRedisSerializer()))
-            .serializeValuesWith(
-                RedisSerializationContext.SerializationPair.fromSerializer(
-                    GenericJackson2JsonRedisSerializer()
-                )
-            )
-            .entryTtl(Duration.ofMinutes(10))
-
-        return RedisCacheManager
-            .RedisCacheManagerBuilder
-            .fromConnectionFactory(factory!!)
-            .cacheDefaults(cacheConfig)
-            .build()
-    }
-
-    @Bean
-    fun userCacheManager(factory: RedisConnectionFactory?): CacheManager {
+    fun redisCacheManager(factory: RedisConnectionFactory?): CacheManager {
         val cacheConfig = RedisCacheConfiguration.defaultCacheConfig()
             .serializeKeysWith(RedisSerializationContext.SerializationPair.fromSerializer(StringRedisSerializer()))
             .serializeValuesWith(

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -20,7 +20,7 @@ spring:
     type: redis
     cache-names:
         - Clients
-        - AcceptedUser
+        - AcceptedUsers
 
   redis:
     host: ${REDIS_HOST}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -16,6 +16,11 @@ spring:
     password: ${DB_PASSWORD}
     driver-class-name: ${DB_DRIVER_CLASS}
 
+  cache:
+    type: redis
+    cache-names:
+        - Clients
+        - AcceptedUser
 
   redis:
     host: ${REDIS_HOST}


### PR DESCRIPTION
## 💡 배경 및 개요

메인 페이지의 등록된 서비스(PUBLIC) 리스트와 관리자 페이지의 유저 리스트에 레디스를 이용하여 캐시를 적용하였습니다.

등록된 서비스 캐시 적용 전
<img width="850" alt="스크린샷 2024-09-01 오후 11 25 10" src="https://github.com/user-attachments/assets/193d363d-66f6-46e7-b3b4-225ee6e66071">

등록된 서비스 캐시 적용 후
<img width="853" alt="스크린샷 2024-09-01 오후 11 20 45" src="https://github.com/user-attachments/assets/bee4b693-d855-454d-addb-47fa48933f2d">

유저 리스트 캐시 적용 전
<img width="854" alt="스크린샷 2024-09-03 오전 11 19 35" src="https://github.com/user-attachments/assets/43471a7e-58a9-4a9a-b89b-2af5b20f71b5">


유저 리스트 캐시 적용 후
<img width="854" alt="스크린샷 2024-09-03 오전 11 19 47" src="https://github.com/user-attachments/assets/9636cba4-04a0-4463-9359-827244e50268">

Resolves: #346 

## 📃 작업내용

레디스 캐시에 대한 설정을 추가하였고 유저에 관한 캐시매니저와 서비스에 관한 캐시매니저를 따로 두어 관리하고 유저 리스트를 불러오는 api를 호출하면 캐시에 올라가고 유저 수락 api가 호출되면 올라간 캐시는 사라집니다.

서비스 캐시는 PUBLIC으로 되어있는 서비스를 반환하는 api가 호출되면 캐시에 올라가고 서비스에 관한 모든 CUD api가 호출되면 모든 엔트리는 삭제됩니다.

## 🙋‍♂️ 리뷰노트

아직 캐시에 대한 이해도가 부족하여 감안하고 코드리뷰 부탁드립니다!
데이터베이스의 이슈로 유저에 관한 캐시 테스트를 하지 못해 pr을 확인해주시면서 브랜치로 이동해주셔서 테스트 한번만 해주시면 감사하겠습니다! 

24/9/3
유저 리스트 관한 테스트 진행 후 이상 없음을 확인하였습니다.

## ✅ PR 체크리스트

> 템플릿 체크리스트 말고도 추가적으로 필요한 체크리스트는 추가해주세요!

- [x] 이 작업으로 인해 변경이 필요한 문서가 변경되었나요? (e.g. `.env`, `노션`, `README`)
- [x] 이 작업을 하고나서 공유해야할 팀원들에게 공유되었나요? (e.g. `"API 개발 완료됐어요"`, `"환경값 추가되었어요"`)
- [x] 작업한 코드가 정상적으로 동작하나요?
- [x] Merge 대상 브랜치가 올바른가요?
- [x] PR과 관련 없는 작업이 있지는 않나요?
- [x] 이 작업으로 인해 발생한 변경 사항이 Resource 서버에도 반영되었나요?

## 🎸 기타